### PR TITLE
CombineHarvester: support for counting-experiment datacards

### DIFF
--- a/CombineTools/interface/CombineHarvester.h
+++ b/CombineTools/interface/CombineHarvester.h
@@ -117,6 +117,7 @@ class CombineHarvester {
 
   void WriteDatacard(std::string const& name, std::string const& root_file);
   void WriteDatacard(std::string const& name, TFile & root_file);
+  void WriteDatacard(std::string const& name);
   /**@}*/
 
   /**

--- a/CombineTools/interface/HistMapping.h
+++ b/CombineTools/interface/HistMapping.h
@@ -15,6 +15,7 @@ namespace ch {
     std::shared_ptr<TFile> file;
     std::shared_ptr<RooWorkspace> ws;
     std::shared_ptr<RooWorkspace> sys_ws;
+    bool is_fake;
     bool IsHist() const;
     bool IsPdf() const;
     bool IsData() const;
@@ -23,7 +24,7 @@ namespace ch {
     std::string SystWorkspaceName() const;
     std::string SystWorkspaceObj() const;
 
-    HistMapping() = default;
+    HistMapping();
     HistMapping(std::string const& p, std::string const& c,
                 std::string const& pat, std::string const& s_pat);
 

--- a/CombineTools/interface/Logging.h
+++ b/CombineTools/interface/Logging.h
@@ -10,7 +10,7 @@ namespace ch {
 
 #define LOGLINE(x, y) LogLine(x, __func__, y)
 
-#define FNLOG(x) x << "[" << __func__ << "]"
+#define FNLOG(x) x << "[" << __func__ << "] "
 #define FNLOGC(x, y) if (y) x << "[" << __func__ << "] "
 /**
  * \brief Writes a logging message to a given ostream

--- a/CombineTools/src/CombineHarvester_Python.cc
+++ b/CombineTools/src/CombineHarvester_Python.cc
@@ -122,6 +122,9 @@ int (CombineHarvester::*Overload2_ParseDatacard)(
 void (CombineHarvester::*Overload1_WriteDatacard)(
     std::string const&, std::string const&) = &CombineHarvester::WriteDatacard;
 
+void (CombineHarvester::*Overload2_WriteDatacard)(
+    std::string const&) = &CombineHarvester::WriteDatacard;
+
 double (CombineHarvester::*Overload1_GetUncertainty)(
     void) = &CombineHarvester::GetUncertainty;
 
@@ -225,6 +228,7 @@ BOOST_PYTHON_MODULE(libCombineHarvesterCombineTools)
       .def("__ParseDatacard__", Overload1_ParseDatacard)
       .def("QuickParseDatacard", Overload2_ParseDatacard)
       .def("WriteDatacard", Overload1_WriteDatacard)
+      .def("WriteDatacard", Overload2_WriteDatacard)
       // Filters
       .def("bin", &CombineHarvester::bin,
           defaults_bin()[py::return_internal_reference<>()])

--- a/CombineTools/src/HistMapping.cc
+++ b/CombineTools/src/HistMapping.cc
@@ -4,74 +4,73 @@
 
 namespace ch {
 
+HistMapping::HistMapping() : is_fake(false) {}
+
 HistMapping::HistMapping(std::string const& p, std::string const& c,
                          std::string const& pat, std::string const& s_pat)
-    : process(p), category(c), pattern(pat), syst_pattern(s_pat) {}
+    : process(p), category(c), pattern(pat), syst_pattern(s_pat), is_fake(false) {}
 
-  bool HistMapping::IsHist() const {
-    if (pattern.find(':') == pattern.npos) {
-      return true;
-    } else {
-      return false;
-    }
+bool HistMapping::IsHist() const {
+  if (pattern.size() > 0 && pattern.find(':') == pattern.npos) {
+    return true;
+  } else {
+    return false;
   }
+}
 
-  bool HistMapping::IsPdf() const {
-    if (pattern.find(':') != pattern.npos) {
-      return true;
-    } else {
-      return false;
-    }
+bool HistMapping::IsPdf() const {
+  if (pattern.size() > 0 && pattern.find(':') != pattern.npos) {
+    return true;
+  } else {
+    return false;
   }
+}
 
-  bool HistMapping::IsData() const {
-    if (pattern.find(':') != pattern.npos) {
-      return true;
-    } else {
-      return false;
-    }
+bool HistMapping::IsData() const {
+  if (pattern.size() > 0 && pattern.find(':') != pattern.npos) {
+    return true;
+  } else {
+    return false;
   }
+}
 
-  std::string HistMapping::WorkspaceName() const {
-    std::size_t colon = pattern.find_last_of(':');
-    if (colon != pattern.npos) {
-      return pattern.substr(0, colon);
-    } else {
-      return std::string();
-    }
+std::string HistMapping::WorkspaceName() const {
+  std::size_t colon = pattern.find_last_of(':');
+  if (colon != pattern.npos) {
+    return pattern.substr(0, colon);
+  } else {
+    return std::string();
   }
-  std::string HistMapping::WorkspaceObj() const {
-    std::size_t colon = pattern.find_last_of(':');
-    if (colon != pattern.npos) {
-      return pattern.substr(colon+1);
-    } else {
-      return std::string();
-    }
+}
+std::string HistMapping::WorkspaceObj() const {
+  std::size_t colon = pattern.find_last_of(':');
+  if (colon != pattern.npos) {
+    return pattern.substr(colon + 1);
+  } else {
+    return std::string();
   }
-  std::string HistMapping::SystWorkspaceName() const {
-    std::size_t colon = syst_pattern.find_last_of(':');
-    if (colon != syst_pattern.npos) {
-      return syst_pattern.substr(0, colon);
-    } else {
-      return std::string();
-    }
+}
+std::string HistMapping::SystWorkspaceName() const {
+  std::size_t colon = syst_pattern.find_last_of(':');
+  if (colon != syst_pattern.npos) {
+    return syst_pattern.substr(0, colon);
+  } else {
+    return std::string();
   }
-  std::string HistMapping::SystWorkspaceObj() const {
-    std::size_t colon = syst_pattern.find_last_of(':');
-    if (colon != syst_pattern.npos) {
-      return syst_pattern.substr(colon+1);
-    } else {
-      return std::string();
-    }
+}
+std::string HistMapping::SystWorkspaceObj() const {
+  std::size_t colon = syst_pattern.find_last_of(':');
+  if (colon != syst_pattern.npos) {
+    return syst_pattern.substr(colon + 1);
+  } else {
+    return std::string();
   }
+}
 
-  std::ostream& operator<<(std::ostream& out, HistMapping const& val) {
-    out << boost::format("%-7s %-7s %-20s %-20s %-20s")
-    % val.process
-    % val.category
-    % (val.file.get() ? val.file->GetName() : "0")
-    % val.pattern
-    % val.syst_pattern;
-    return out;
-  }
+std::ostream& operator<<(std::ostream& out, HistMapping const& val) {
+  out << boost::format("%-7s %-7s %-20s %-20s %-20s") % val.process %
+             val.category % (val.file.get() ? val.file->GetName() : "0") %
+             val.pattern % val.syst_pattern;
+  return out;
+}
 }


### PR DESCRIPTION
Closes #18. CombineHarvester can now parse datacards that do not contain
"shape" directives, or that contain "FAKE" shape directives. When writing a
datacard, a bin will be given the "FAKE" shape directive if none of the
Observation and Process objects in that bin refer to a shape, RooDataHist or
RooAbsPdf.

In detail:

 -  New overload method `WriteDatacard(std::string const& name)` that can be
    used when there is no shape information to write. If an object does
    reference a shape then the method will throw. Also added to the python
    interface.
 -  WriteDatacard would previously throw if the supplied TFile was not open.
    As we now use a dummy TFile for counting-only datacards, this throw is
    only triggered when there is a shape to write and the TFile is not open.
 -  The HistMapping class now has a boolean data member `is_fake`, this is
    checked in the LoadShapes methods to avoid making any attempt to read from
    a non-existent ROOT file.
 -  The LoadShapes methods also check at the beginning if the list of
    HistMappings is empty, and if so return immediately, under the assumption
    that must be a counting-only datacard.