### PR TITLE
fixing compiler error in root6

### DIFF
--- a/CombineTools/src/SOverBTools.cc
+++ b/CombineTools/src/SOverBTools.cc
@@ -36,9 +36,9 @@ SOverBInfo::SOverBInfo(TH1F const* sig, TH1F const* bkg, unsigned steps,
 }
 
 double IntegrateFloatRange(TH1F const* hist, double xmin, double xmax) {
-  TAxis* axis = hist->GetXaxis();
-  int bmin = axis->FindBin(xmin);
-  int bmax = axis->FindBin(xmax);
+  TAxis const* axis = hist->GetXaxis();
+  int bmin = axis->FindFixBin(xmin);
+  int bmax = axis->FindFixBin(xmax);
   double integral = hist->Integral(bmin, bmax);
   integral -= hist->GetBinContent(bmin) * (xmin - axis->GetBinLowEdge(bmin)) /
               axis->GetBinWidth(bmin);


### PR DESCRIPTION
Fairly simple one due the const-ness of a TAxis retrieved from a TH1 changing in root6.