### PR TITLE
Adding Control regions to MSSM run2 datacard setup script

### DIFF
--- a/CombineTools/interface/HttSystematics.h
+++ b/CombineTools/interface/HttSystematics.h
@@ -30,7 +30,7 @@ void AddMSSMUpdateSystematics_tt(CombineHarvester& cb);
 
 // Run2 MSSM analysis systematics
 // Implemented in src/HttSystematics_MSSMRun2.cc
-void AddMSSMRun2Systematics(CombineHarvester& cb);
+void AddMSSMRun2Systematics(CombineHarvester& cb, int control_region);
 
 // Hhh systematics
 // Implemented in src/HhhSystematics.cc

--- a/CombineTools/src/HttSystematics_MSSMRun2.cc
+++ b/CombineTools/src/HttSystematics_MSSMRun2.cc
@@ -16,8 +16,13 @@ using ch::syst::process;
 using ch::JoinStr;
 
 
-void AddMSSMRun2Systematics(CombineHarvester & cb) {
+void AddMSSMRun2Systematics(CombineHarvester & cb, int control_region = 0) {
   CombineHarvester src = cb.cp();
+  
+  if (control_region == 1){
+    //limit to only the btag and nobtag categories
+    src.bin_id({8,9});
+  }
 
   auto signal = Set2Vec(src.cp().signals().SetFromProcs(
       std::mem_fn(&Process::process)));
@@ -116,30 +121,6 @@ void AddMSSMRun2Systematics(CombineHarvester & cb) {
   
  src.cp().channel({"et","tt","mt"}).process({"ZL","ZJ"}).AddSyst(cb, "CMS_htt_zttNorm_13TeV", "lnN", SystMap<>::init(1.03));
 
- // QCD Normalisation - separate nuisance for each channel/category
- src.cp().process({"QCD"}).channel({"mt"}).bin_id({8}).AddSyst(cb,
-      "CMS_htt_QCDNorm_mt_nobtag_13TeV","lnN",SystMap<>::init(1.1));
- 
- src.cp().process({"QCD"}).channel({"mt"}).bin_id({9}).AddSyst(cb,
-      "CMS_htt_QCDNorm_mt_btag_13TeV","lnN",SystMap<>::init(1.3));
- 
- src.cp().process({"QCD"}).channel({"et"}).bin_id({8}).AddSyst(cb,
-      "CMS_htt_QCDNorm_et_nobtag_13TeV","lnN",SystMap<>::init(1.1));
- 
- src.cp().process({"QCD"}).channel({"et"}).bin_id({9}).AddSyst(cb,
-      "CMS_htt_QCDNorm_et_btag_13TeV","lnN",SystMap<>::init(1.3));
- 
- src.cp().process({"QCD"}).channel({"tt"}).bin_id({8}).AddSyst(cb,
-      "CMS_htt_QCDNorm_tt_nobtag_13TeV","lnN",SystMap<>::init(1.35));
- 
- src.cp().process({"QCD"}).channel({"tt"}).bin_id({9}).AddSyst(cb,
-      "CMS_htt_QCDNorm_tt_btag_13TeV","lnN",SystMap<>::init(1.35));
- 
- src.cp().process({"QCD"}).channel({"em"}).bin_id({8}).AddSyst(cb,
-      "CMS_htt_QCDNorm_em_nobtag_13TeV","lnN",SystMap<>::init(1.3));
- 
- src.cp().process({"QCD"}).channel({"em"}).bin_id({9}).AddSyst(cb,
-      "CMS_htt_QCDNorm_em_btag_13TeV","lnN",SystMap<>::init(1.3));
 
  // Diboson and ttbar Normalisation - fully correlated
  src.cp().process({"VV"}).AddSyst(cb,
@@ -149,32 +130,81 @@ void AddMSSMRun2Systematics(CombineHarvester & cb) {
       .AddSyst(cb, "CMS_htt_ttbarNorm_13TeV", "lnN", SystMap<era>::init
         ({"13TeV"}, 1.10));
 
- // W Normalisation - separate nuisance for each channel/category
- 
- src.cp().process({"W"}).channel({"mt"}).bin_id({8}).AddSyst(cb,
-      "CMS_htt_WNorm_mt_nobtag_13TeV","lnN",SystMap<>::init(1.1));
- 
- src.cp().process({"W"}).channel({"mt"}).bin_id({9}).AddSyst(cb,
-      "CMS_htt_WNorm_mt_btag_13TeV","lnN",SystMap<>::init(1.3));
- 
- src.cp().process({"W"}).channel({"et"}).bin_id({8}).AddSyst(cb,
-      "CMS_htt_WNorm_et_nobtag_13TeV","lnN",SystMap<>::init(1.1));
- 
- src.cp().process({"W"}).channel({"et"}).bin_id({9}).AddSyst(cb,
-      "CMS_htt_WNorm_et_btag_13TeV","lnN",SystMap<>::init(1.3));
- 
- src.cp().process({"W"}).channel({"tt"}).bin_id({8}).AddSyst(cb,
-      "CMS_htt_WNorm_tt_nobtag_13TeV","lnN",SystMap<>::init(1.3));
- 
- src.cp().process({"W"}).channel({"tt"}).bin_id({9}).AddSyst(cb,
-      "CMS_htt_WNorm_tt_btag_13TeV","lnN",SystMap<>::init(1.3));
- 
- src.cp().process({"W"}).channel({"em"}).bin_id({8}).AddSyst(cb,
-      "CMS_htt_WNorm_em_nobtag_13TeV","lnN",SystMap<>::init(1.3));
- 
- src.cp().process({"W"}).channel({"em"}).bin_id({9}).AddSyst(cb,
-      "CMS_htt_WNorm_em_btag_13TeV","lnN",SystMap<>::init(1.3));
 
+  if (control_region == 0 || control_region == 1) {
+    // the uncertainty model in the signal region is the classical one
+    // QCD Normalisation - separate nuisance for each channel/category
+    src.cp().process({"QCD"}).channel({"mt"}).bin_id({8}).AddSyst(cb,
+        "CMS_htt_QCDNorm_mt_nobtag_13TeV","lnN",SystMap<>::init(1.1));
+    
+    src.cp().process({"QCD"}).channel({"mt"}).bin_id({9}).AddSyst(cb,
+        "CMS_htt_QCDNorm_mt_btag_13TeV","lnN",SystMap<>::init(1.3));
+    
+    src.cp().process({"QCD"}).channel({"et"}).bin_id({8}).AddSyst(cb,
+        "CMS_htt_QCDNorm_et_nobtag_13TeV","lnN",SystMap<>::init(1.1));
+    
+    src.cp().process({"QCD"}).channel({"et"}).bin_id({9}).AddSyst(cb,
+        "CMS_htt_QCDNorm_et_btag_13TeV","lnN",SystMap<>::init(1.3));
+    
+    src.cp().process({"QCD"}).channel({"tt"}).bin_id({8}).AddSyst(cb,
+        "CMS_htt_QCDNorm_tt_nobtag_13TeV","lnN",SystMap<>::init(1.35));
+    
+    src.cp().process({"QCD"}).channel({"tt"}).bin_id({9}).AddSyst(cb,
+        "CMS_htt_QCDNorm_tt_btag_13TeV","lnN",SystMap<>::init(1.35));
+    
+    src.cp().process({"QCD"}).channel({"em"}).bin_id({8}).AddSyst(cb,
+        "CMS_htt_QCDNorm_em_nobtag_13TeV","lnN",SystMap<>::init(1.3));
+    
+    src.cp().process({"QCD"}).channel({"em"}).bin_id({9}).AddSyst(cb,
+        "CMS_htt_QCDNorm_em_btag_13TeV","lnN",SystMap<>::init(1.3));
+        src.cp().process({"W"}).channel({"mt"}).AddSyst(cb,
+            "CMS_htt_WNorm_13TeV","lnN",SystMap<>::init(1.2));
 
-}
+    // W Normalisation - separate nuisance for each channel/category
+    
+    src.cp().process({"W"}).channel({"mt"}).bin_id({8}).AddSyst(cb,
+        "CMS_htt_WNorm_mt_nobtag_13TeV","lnN",SystMap<>::init(1.1));
+    
+    src.cp().process({"W"}).channel({"mt"}).bin_id({9}).AddSyst(cb,
+        "CMS_htt_WNorm_mt_btag_13TeV","lnN",SystMap<>::init(1.3));
+    
+    src.cp().process({"W"}).channel({"et"}).bin_id({8}).AddSyst(cb,
+        "CMS_htt_WNorm_et_nobtag_13TeV","lnN",SystMap<>::init(1.1));
+    
+    src.cp().process({"W"}).channel({"et"}).bin_id({9}).AddSyst(cb,
+        "CMS_htt_WNorm_et_btag_13TeV","lnN",SystMap<>::init(1.3));
+    
+    src.cp().process({"W"}).channel({"tt"}).bin_id({8}).AddSyst(cb,
+        "CMS_htt_WNorm_tt_nobtag_13TeV","lnN",SystMap<>::init(1.3));
+    
+    src.cp().process({"W"}).channel({"tt"}).bin_id({9}).AddSyst(cb,
+        "CMS_htt_WNorm_tt_btag_13TeV","lnN",SystMap<>::init(1.3));
+    
+    src.cp().process({"W"}).channel({"em"}).bin_id({8}).AddSyst(cb,
+        "CMS_htt_WNorm_em_nobtag_13TeV","lnN",SystMap<>::init(1.3));
+    
+    src.cp().process({"W"}).channel({"em"}).bin_id({9}).AddSyst(cb,
+        "CMS_htt_WNorm_em_btag_13TeV","lnN",SystMap<>::init(1.3));
+    }
+    if (control_region == 1 || control_region == 2) {
+      // setup rateParams
+      std::map<std::string,int> base_categories{{"btag",10},{"nobtag",13}};
+      for (auto bin:src.cp().bin_id({8,9}).bin_set()){
+        // use cb as we need all categories
+        // Add rateParam for W in OS
+        cb.cp().process({"W"}).channel({bin.substr(0,2)}).AddSyst(cb, "wjets_rate_"+bin+"_os","rateParam", SystMap<bin_id>::init({*(src.cp().bin({bin}).bin_id_set().begin()),base_categories[bin.substr(3)]},1.0));
+        // Add rateParam for W in SS
+        cb.cp().process({"W"}).channel({bin.substr(0,2)}).AddSyst(cb, "wjets_rate_"+bin+"_ss","rateParam", SystMap<bin_id>::init({base_categories[bin.substr(3)]+1,base_categories[bin.substr(3)]+2},1.0));
+        // Add rateParam for QCD
+        cb.cp().process({"QCD"}).channel({bin.substr(0,2)}).AddSyst(cb, "qcd_rate_"+bin,"rateParam", SystMap<bin_id>::init({*(src.cp().bin({bin}).bin_id_set().begin()),base_categories[bin.substr(3)]+1},1.0));
+      }
+    }
+    if (control_region == 2) {
+      // add the systematic on W+Jets and QCD in the signal region to account for scale factor uncertianties
+      src.cp().process({"QCD"}).channel({"et","em","tt","mt"}).bin_id({8,9}).AddSyst(cb,
+          "CMS_htt_QCD_13TeV","lnN",SystMap<>::init(1.2));
+      src.cp().process({"W"}).channel({"mt"}).bin_id({8,9}).AddSyst(cb,
+          "CMS_htt_WNorm_13TeV","lnN",SystMap<>::init(1.1));
+    }
+  }
 }

--- a/CombineTools/src/HttSystematics_MSSMRun2.cc
+++ b/CombineTools/src/HttSystematics_MSSMRun2.cc
@@ -20,7 +20,8 @@ void AddMSSMRun2Systematics(CombineHarvester & cb, int control_region = 0) {
   CombineHarvester src = cb.cp();
   
   if (control_region == 1){
-    //limit to only the btag and nobtag categories
+    // we only want to cosider systematic uncertainties in the signal region.
+    // limit to only the btag and nobtag categories
     src.bin_id({8,9});
   }
 
@@ -188,19 +189,20 @@ void AddMSSMRun2Systematics(CombineHarvester & cb, int control_region = 0) {
     }
     if (control_region == 1 || control_region == 2) {
       // setup rateParams
+      // this map is needed for bookkeeping of the control-region bin-ids
       std::map<std::string,int> base_categories{{"btag",10},{"nobtag",13}};
       for (auto bin:src.cp().bin_id({8,9}).bin_set()){
         // use cb as we need all categories
         // Add rateParam for W in OS
-        cb.cp().process({"W"}).channel({bin.substr(0,2)}).AddSyst(cb, "wjets_rate_"+bin+"_os","rateParam", SystMap<bin_id>::init({*(src.cp().bin({bin}).bin_id_set().begin()),base_categories[bin.substr(3)]},1.0));
+        cb.cp().process({"W"}).channel({bin.substr(0,2)}).AddSyst(cb, "wjets_os_rate_"+bin,"rateParam", SystMap<bin_id>::init({*(src.cp().bin({bin}).bin_id_set().begin()),base_categories[bin.substr(3)]},1.0));
         // Add rateParam for W in SS
-        cb.cp().process({"W"}).channel({bin.substr(0,2)}).AddSyst(cb, "wjets_rate_"+bin+"_ss","rateParam", SystMap<bin_id>::init({base_categories[bin.substr(3)]+1,base_categories[bin.substr(3)]+2},1.0));
+        cb.cp().process({"W"}).channel({bin.substr(0,2)}).AddSyst(cb, "wjets_ss_rate_"+bin,"rateParam", SystMap<bin_id>::init({base_categories[bin.substr(3)]+1,base_categories[bin.substr(3)]+2},1.0));
         // Add rateParam for QCD
         cb.cp().process({"QCD"}).channel({bin.substr(0,2)}).AddSyst(cb, "qcd_rate_"+bin,"rateParam", SystMap<bin_id>::init({*(src.cp().bin({bin}).bin_id_set().begin()),base_categories[bin.substr(3)]+1},1.0));
       }
     }
     if (control_region == 2) {
-      // add the systematic on W+Jets and QCD in the signal region to account for scale factor uncertianties
+      // add the systematic on W+Jets and QCD in the signal region to account for scale factor uncertainties
       src.cp().process({"QCD"}).channel({"et","em","tt","mt"}).bin_id({8,9}).AddSyst(cb,
           "CMS_htt_QCD_13TeV","lnN",SystMap<>::init(1.2));
       src.cp().process({"W"}).channel({"mt"}).bin_id({8,9}).AddSyst(cb,

--- a/HIG16006/bin/MorphingMSSMRun2.cpp
+++ b/HIG16006/bin/MorphingMSSMRun2.cpp
@@ -8,6 +8,7 @@
 #include "boost/algorithm/string/predicate.hpp"
 #include "boost/program_options.hpp"
 #include "boost/lexical_cast.hpp"
+#include "boost/regex.hpp"
 #include "CombineHarvester/CombineTools/interface/CombineHarvester.h"
 #include "CombineHarvester/CombineTools/interface/Observation.h"
 #include "CombineHarvester/CombineTools/interface/Process.h"
@@ -25,6 +26,16 @@ using namespace std;
 using boost::starts_with;
 namespace po = boost::program_options;
 
+template <typename T>
+void To1Bin(T* proc)
+{
+    TH1F *hist = new TH1F("hist","hist",1,0,1);
+    hist->SetDirectory(0);
+    hist->SetBinContent(1,proc->ClonedScaledShape()->Integral(0,proc->ClonedScaledShape()->GetNbinsX()+1));
+    proc->set_shape(*hist,true);
+}
+
+
 int main(int argc, char** argv) {
   // First define the location of the "auxiliaries" directory where we can
   // source the input files containing the datacard shapes
@@ -35,6 +46,7 @@ int main(int argc, char** argv) {
   string postfix="";
   bool auto_rebin = false;
   bool manual_rebin = false;
+  int control_region = 0;
   po::variables_map vm;
   po::options_description config("configuration");
   config.add_options()
@@ -44,7 +56,8 @@ int main(int argc, char** argv) {
     ("auto_rebin", po::value<bool>(&auto_rebin)->default_value(false))
     ("manual_rebin", po::value<bool>(&manual_rebin)->default_value(false))
     ("output_folder", po::value<string>(&output_folder)->default_value("mssm_run2"))
-    ("SM125,h", po::value<string>(&SM125)->default_value(SM125));
+    ("SM125,h", po::value<string>(&SM125)->default_value(SM125))
+    ("control_region", po::value<int>(&control_region)->default_value(0));
   po::store(po::command_line_parser(argc, argv).options(config).run(), vm);
   po::notify(vm);
   
@@ -111,7 +124,24 @@ int main(int argc, char** argv) {
     {8, "mt_nobtag"},
     {9, "mt_btag"}
     };
- 
+
+  if (control_region > 0){
+      // for each channel use the categories >= 10 for the control regions
+      // the control regions are ordered in triples (10,11,12),(13,14,15)...
+      for (auto chn:chns){
+          // for em do nothing
+          if ( chn == "em") continue;
+          Categories queue;
+          int binid = 10;
+          for (auto cat:cats[chn+"_13TeV"]){
+            queue.push_back(make_pair(binid,cat.second+"_wjets_cr"));
+            queue.push_back(make_pair(binid+1,cat.second+"_qcd_cr"));
+            queue.push_back(make_pair(binid+2,cat.second+"_wjets_ss_cr"));
+            binid += 3;
+          }
+          cats[chn+"_13TeV"].insert(cats[chn+"_13TeV"].end(),queue.begin(),queue.end());
+      }
+  }
 
   vector<string> masses = {"90","100","110","120","130","140","160","180", "250", "300", "450", "500", "600", "700", "900","1000","1200","1500","1600","1800","2000","2600","2900","3200"}; //Not all mass points available for fall15
   //vector<string> masses = {"90","100","110","120","130","140","160","180", "200", "250", "300", "350", "400", "450", "500", "600", "700", "800", "900","1000","1200","1400","1500","1600","1800","2000","2300","2600","2900","3200"};
@@ -135,9 +165,15 @@ int main(int argc, char** argv) {
     cb.AddProcesses(masses, {"htt"}, {"13TeV"}, {chn}, signal_types["ggH"], cats[chn+"_13TeV"], true);
     cb.AddProcesses(masses, {"htt"}, {"13TeV"}, {chn}, signal_types["bbH"], cats[chn+"_13TeV"], true);
     }
+  if (control_region > 0){
+      // filter QCD in W+jets control regions
+      // filter signal processes in control regions
+      cb.FilterAll([](ch::Object const* obj) {
+              return (((obj->bin().find("_wjets_") != std::string::npos) && (obj->process() == "QCD")) || (boost::regex_search(obj->bin(),boost::regex{"_cr"}) && obj->signal()));
+              });
+  } 
 
-
-  ch::AddMSSMRun2Systematics(cb);
+  ch::AddMSSMRun2Systematics(cb,control_region);
   //! [part7]
   for (string chn:chns){
     cb.cp().channel({chn}).backgrounds().ExtractShapes(
@@ -160,6 +196,8 @@ int main(int argc, char** argv) {
         obs->set_shape(cb.cp().bin({b}).backgrounds().GetShape(), true);
         });
     } 
+    cb.cp().FilterAll([](ch::Object const* obj) { return ! (boost::regex_search(obj->bin(),boost::regex{"_cr"}));}).ForEachProc(To1Bin<ch::Process>);
+    cb.cp().FilterAll([](ch::Object const* obj) { return ! (boost::regex_search(obj->bin(),boost::regex{"_cr"}));}).ForEachObs(To1Bin<ch::Observation>);
   
 
   auto rebin = ch::AutoRebin()
@@ -182,7 +220,9 @@ int main(int argc, char** argv) {
     .SetAddThreshold(0.)
     .SetMergeThreshold(0.4)
     .SetFixNorm(true);
-  bbb.MergeAndAdd(cb.cp().process({"ZTT", "QCD", "W", "ZJ", "ZL", "TT", "VV", "Ztt", "ttbar", "EWK", "Fakes", "ZMM", "TTJ", "WJets", "Dibosons"}), cb); 
+  bbb.MergeAndAdd(cb.cp().process({"ZTT", "QCD", "W", "ZJ", "ZL", "TT", "VV", "Ztt", "ttbar", "EWK", "Fakes", "ZMM", "TTJ", "WJets", "Dibosons"}).FilterAll([](ch::Object const* obj) {
+              return (boost::regex_search(obj->bin(),boost::regex{"_cr"}));
+              }), cb);
   cout << " done\n";
 
   //Switch JES over to lnN:
@@ -272,6 +312,7 @@ int main(int argc, char** argv) {
       }
   }
      
+  cb.PrintAll();
   cout << " done\n";
 
 


### PR DESCRIPTION
This PR adds a first implementation for using control regions to the MSSM Run 2 datacard setup script. It currently supports 3 modi:
1) only signal region (same as before, default modus)
2) signal region + control region, where the control region only contributes constraints based on the statistics (i.e. no systematics applied in these regions)
3) signal region + control region, applying the full uncertainty model in the control region. Currently all systematics which are applied are considered fully correlated with the signal region. One outstanding point here is to take care of shape systematics which currently would be applied in the control regions. 

From the input side using the new modi requires having three additional selections per category in your root-files. These are (with $CATEGORY is nobtag, btag)
1) $CATEGORY_wjets_cr, (OS, high mT region)
3) $CATEGORY_wjets_ss_cr (SS, high mT region)
2) $CATEGORY_qcd_cr (SS, low mT region)
The histograms can be provided with any binning and will be rebinned to a 1-bin category in the script.

Please feel free to comment, discuss and make suggestions.

Cheers,
Rene