### PR TITLE
Changing batch submission setup

### DIFF
--- a/CombineTools/input/job_prefixes/job_prefix_ic.txt
+++ b/CombineTools/input/job_prefixes/job_prefix_ic.txt
@@ -1,0 +1,8 @@
+#!/bin/sh
+ulimit -s unlimited
+cd %(CMSSW_BASE)s/src
+export SCRAM_ARCH=%(SCRAM_ARCH)s
+source /vols/cms/grid/setup.sh
+eval `scramv1 runtime -sh`
+cd %(PWD)s
+

--- a/CombineTools/input/job_prefixes/job_prefix_ic.txt
+++ b/CombineTools/input/job_prefixes/job_prefix_ic.txt
@@ -5,4 +5,3 @@ export SCRAM_ARCH=%(SCRAM_ARCH)s
 source /vols/cms/grid/setup.sh
 eval `scramv1 runtime -sh`
 cd %(PWD)s
-

--- a/CombineTools/input/job_prefixes/job_prefix_naf.txt
+++ b/CombineTools/input/job_prefixes/job_prefix_naf.txt
@@ -1,0 +1,18 @@
+#!/bin/sh
+ulimit -s unlimited
+cd %(CMSSW_BASE)s/src
+linux_ver=`lsb_release -s -r`
+echo $linux_ver
+if [[ $linux_ver < 6.0 ]];
+then
+     eval "`/afs/desy.de/common/etc/local/ini/ini.pl cmssw_cvmfs`"
+     export SCRAM_ARCH=slc5_amd64_gcc472
+     export SCRAM_ARCH=%(SCRAM_ARCH)s
+else
+     source /cvmfs/cms.cern.ch/cmsset_default.sh
+     export SCRAM_ARCH=slc6_amd64_gcc472
+     export SCRAM_ARCH=%(SCRAM_ARCH)s
+fi
+
+eval `scramv1 runtime -sh`
+cd %(PWD)s

--- a/CombineTools/python/combine/CombineToolBase.py
+++ b/CombineTools/python/combine/CombineToolBase.py
@@ -187,7 +187,10 @@ class CombineToolBase:
         script_list = []
         if self.job_mode in ['script', 'lxbatch', 'SGE']:
             if self.prefix_file != '':
-                job_prefix_file = open(self.prefix_file,'r')
+                if self.prefix_file.endswith('.txt'):
+                  job_prefix_file = open(self.prefix_file,'r')
+                else :
+                  job_prefix_file = open(os.environ['CMSSW_BASE']+"/src/CombineHarvester/CombineTools/input/job_prefixes/job_prefix_"+self.prefix_file+".txt",'r')
                 global JOB_PREFIX
                 JOB_PREFIX=job_prefix_file.read() %({
                   'CMSSW_BASE': os.environ['CMSSW_BASE'],


### PR DESCRIPTION
This changes the combineTool batch submission options: instead of a separate JOB_PREFIX  and job mode for every batch system, with this we have:
- Two job modes ('lxbatch', for LSF job submission, and 'SGE')
- a default JOB_PREFIX, set to the prefix needed for submission to the lxbatch
- an option --prefix-file to specify the path to a text file containing a modified job prefix (e.g. if the environment needs to be set up differently at other sites). Two such files currently live in CombineTools/input/job_prefixes. Specifying a modified job prefix file overrides the default JOB_PREFIX