### PR TITLE
Allow for different styles of the limit plots

### DIFF
--- a/CombineTools/python/plotting.py
+++ b/CombineTools/python/plotting.py
@@ -1445,11 +1445,9 @@ def StyleLimitBand(graph_dict, overwrite_style_dict=None):
     for key in graph_dict:
         Set(graph_dict[key],**style_dict[key])
 
-def DrawLimitBand(pad, graph_dict, draw=['obs', 'exp0', 'exp1', 'exp2'],
+def DrawLimitBand(pad, graph_dict, draw=['exp2', 'exp1', 'exp0', 'obs'], draw_legend=None,
                   legend=None, legend_overwrite=None):
     legend_dict = {
-        'DrawOrder' : ['exp2', 'exp1', 'exp0', 'obs'],
-        'LegendOrder' : ['obs', 'exp0', 'exp1', 'exp2'],
         'obs' : { 'Label' : 'Observed', 'LegendStyle' : 'LP', 'DrawStyle' : 'PLSAME'},
         'exp0' : { 'Label' : 'Expected', 'LegendStyle' : 'L', 'DrawStyle' : 'LSAME'},
         'exp1' : { 'Label' : '#pm1#sigma Expected', 'LegendStyle' : 'F', 'DrawStyle' : '3SAME'},
@@ -1462,10 +1460,12 @@ def DrawLimitBand(pad, graph_dict, draw=['obs', 'exp0', 'exp1', 'exp2'],
             else:
                 legend_dict[key] = legend_overwrite[key]
     pad.cd()
-    for key in legend_dict["DrawOrder"]:
+    for key in draw:
         graph_dict[key].Draw(legend_dict[key]['DrawStyle'])
     if legend is not None:
-        for key in legend_dict["LegendOrder"]:
+        if draw_legend is None:
+            draw_legend = reversed(draw)
+        for key in draw_legend:
             legend.AddEntry(graph_dict[key],legend_dict[key]['Label'],legend_dict[key]['LegendStyle'])
 
 

--- a/CombineTools/python/plotting.py
+++ b/CombineTools/python/plotting.py
@@ -1429,67 +1429,46 @@ def DrawTitle(pad, text, align):
 def isclose(a, b, rel_tol=1e-9, abs_tol=0.0):
     return abs(a-b) <= max(abs_tol, rel_tol * max(abs(a),abs(b)))
 
-def StyleLimitBand(graph_dict, higgs_bg=False, higgs_inj=False):
-    if 'obs' in graph_dict:
-        graph_dict['obs'].SetLineWidth(2)
-    if 'exp0' in graph_dict:
-        graph_dict['exp0'].SetLineWidth(2)
-        graph_dict['exp0'].SetLineColor(R.kRed)
-    if 'exp1' in graph_dict:
-        if higgs_bg:
-            graph_dict['exp1'].SetFillColor(R.kGreen+2)
-        elif higgs_inj:
-            graph_dict['exp1'].SetFillColor(R.kAzure-4)
-        else:
-            graph_dict['exp1'].SetFillColor(R.kGreen)
-    if 'exp2' in graph_dict:
-        if higgs_bg:
-            graph_dict['exp2'].SetFillColor(R.kSpring+5)
-        elif higgs_inj:
-            graph_dict['exp2'].SetFillColor(R.kAzure-9)
-        else:
-            graph_dict['exp2'].SetFillColor(R.kYellow)
-
+def StyleLimitBand(graph_dict, overwrite_style_dict=None):
+    style_dict = {
+            'obs' : { 'LineWidth' : 2},
+            'exp0' : { 'LineWidth' : 2, 'LineColor' : R.kRed},
+            'exp1' : { 'FillColor' : R.kGreen},
+            'exp2' : { 'FillColor' : R.kYellow}
+            }
+    if overwrite_style_dict is not None:
+        for key in overwrite_style_dict:
+            if key in style_dict:
+                style_dict[key].update(overwrite_style_dict[key])
+            else:
+                style_dict[key] = overwrite_style_dict[key]
+    for key in graph_dict:
+        Set(graph_dict[key],**style_dict[key])
 
 def DrawLimitBand(pad, graph_dict, draw=['obs', 'exp0', 'exp1', 'exp2'],
-                  legend=None, higgs_bg=False, higgs_inj=False):
+                  legend=None, legend_overwrite=None):
+    legend_dict = {
+        'DrawOrder' : ['exp2', 'exp1', 'exp0', 'obs'],
+        'LegendOrder' : ['obs', 'exp0', 'exp1', 'exp2'],
+        'obs' : { 'Label' : 'Observed', 'LegendStyle' : 'LP', 'DrawStyle' : 'PLSAME'},
+        'exp0' : { 'Label' : 'Expected', 'LegendStyle' : 'L', 'DrawStyle' : 'LSAME'},
+        'exp1' : { 'Label' : '#pm1#sigma Expected', 'LegendStyle' : 'F', 'DrawStyle' : '3SAME'},
+        'exp2' : { 'Label' : '#pm2#sigma Expected', 'LegendStyle' : 'F', 'DrawStyle' : '3SAME'}
+    }
+    if legend_overwrite is not None:
+        for key in legend_overwrite:
+            if key in legend_dict:
+                legend_dict[key].update(legend_overwrite[key])
+            else:
+                legend_dict[key] = legend_overwrite[key]
     pad.cd()
-    do_obs = False
-    do_exp0 = False
-    do_exp1 = False
-    do_exp2 = False
-    if 'exp2' in graph_dict and ('exp2' in draw or 'exp' in draw):
-        do_exp2 = True
-        graph_dict['exp2'].Draw('3SAME')
-    if 'exp1' in graph_dict and ('exp1' in draw or 'exp' in draw):
-        do_exp1 = True
-        graph_dict['exp1'].Draw('3SAME')
-    if 'exp0' in graph_dict and ('exp0' in draw or 'exp' in draw):
-        do_exp0 = True
-        graph_dict['exp0'].Draw('LSAME')
-    if 'obs' in graph_dict and 'obs' in draw:
-        do_obs = True
-        graph_dict['obs'].Draw('PLSAME')
+    for key in legend_dict["DrawOrder"]:
+        graph_dict[key].Draw(legend_dict[key]['DrawStyle'])
     if legend is not None:
-        if do_obs:
-            legend.AddEntry(graph_dict['obs'], 'Observed', 'LP')
-        if do_exp0:
-            if higgs_bg:
-                legend.AddEntry(graph_dict['exp0'], 'Expected for H(125 GeV) as BG', 'L')
-            elif higgs_inj:
-                legend.AddEntry(graph_dict['exp0'], 'Expected for H(125 GeV)', 'L')
-            else:
-                legend.AddEntry(graph_dict['exp0'], 'Expected', 'L')
-        if do_exp1:
-            if higgs_bg:
-                legend.AddEntry(graph_dict['exp1'], '#pm1#sigma H(125 GeV) as BG', 'F')
-            else:
-                legend.AddEntry(graph_dict['exp1'], '#pm1#sigma Expected', 'F')
-        if do_exp2:
-            if higgs_bg:
-                legend.AddEntry(graph_dict['exp2'], '#pm2#sigma H(125 GeV) as BG', 'F')
-            else:
-                legend.AddEntry(graph_dict['exp2'], '#pm2#sigma Expected', 'F')
+        for key in legend_dict["LegendOrder"]:
+            legend.AddEntry(graph_dict[key],legend_dict[key]['Label'],legend_dict[key]['LegendStyle'])
+
+
 
 
 ##@}

--- a/HIG16006/scripts/plotMSSMLimits.py
+++ b/HIG16006/scripts/plotMSSMLimits.py
@@ -47,6 +47,32 @@ parser.add_argument(
 parser.add_argument('--table_vals', help='Amount of values to be written in a table for different masses', default=10)
 args = parser.parse_args()
 
+style_dict_bg = {
+        'style' : {
+            'exp1' : { 'FillColor' : ROOT.kGreen+2},
+            'exp2' : { 'FillColor' : ROOT.kSpring+5}
+            },
+        'legend' : {
+            'exp0' : { 'Label' : 'Expected for H(125 GeV) as BG'},
+            'exp1' : { 'Label' : '#pm1#sigma H(125 GeV) as BG'},
+            'exp2' : { 'Label' : '#pm2#sigma H(125 GeV) as BG'}
+            }
+        }
+style_dict_inj = {
+        'style' : {
+            'exp1' : { 'FillColor' : ROOT.kAzure-4},
+            'exp2' : { 'FillColor' : ROOT.kAzure-9}
+            },
+        'legend' : {
+            'exp0' : { 'Label' : 'Expected for H(125 GeV)'}
+            }
+        }
+
+style_dict=None
+if args.higgs_bg:
+    style_dict = style_dict_bg
+if args.higgs_injected:
+    style_dict = style_dict_inj
 
 def DrawAxisHists(pads, axis_hists, def_pad=None):
     for i, pad in enumerate(pads):
@@ -118,8 +144,12 @@ for src in args.input:
         if axis is None:
             axis = plot.CreateAxisHists(len(pads), graph_sets[-1].values()[0], True)
             DrawAxisHists(pads, axis, pads[0])
-        plot.StyleLimitBand(graph_sets[-1], higgs_bg=args.higgs_bg, higgs_inj=args.higgs_injected)
-        plot.DrawLimitBand(pads[0], graph_sets[-1], legend=legend, higgs_bg=args.higgs_bg, higgs_inj=args.higgs_injected)
+        if args.higgs_bg or args.higgs_injected:
+            plot.StyleLimitBand(graph_sets[-1],overwrite_style_dict=style_dict["style"])
+            plot.DrawLimitBand(pads[0], graph_sets[-1], legend=legend,legend_overwrite=style_dict["legend"])
+        else:
+            plot.StyleLimitBand(graph_sets[-1])
+            plot.DrawLimitBand(pads[0], graph_sets[-1])
         pads[0].RedrawAxis()
         pads[0].RedrawAxis('g')
         pads[0].GetFrame().Draw()


### PR DESCRIPTION
This change is intended to facilitate the usage of different plot styles for the limit plots (for example the green SM higgs as background plot). This is done by having the styles to be used as a dictionary for which individual entries can be overwritten or added by using an optional argument.
Per default the style is applied using the Set function. This implies that all entries which are provided have to correspond to valid ROOT Set... functions.

For the drawing and legend-entries a similar procedure is used allowing to set the draw style as well as the title and marker style in the legend.
