### PR TITLE
Always consider a number of points which is a square number for 2D fits

### DIFF
--- a/CombineTools/python/combine/EnhancedCombine.py
+++ b/CombineTools/python/combine/EnhancedCombine.py
@@ -140,6 +140,7 @@ class EnhancedCombine(CombineToolBase):
                 self.args.split_points > 0 and
                 self.args.points is not None):
             points = int(self.args.points)
+            points = math.ceil(points**0.5)**2
             split = self.args.split_points
             start = 0
             ranges = []


### PR DESCRIPTION
This change takes care of assigning all points for a 2D fit to the respective jobs in case not all points are run in one go.
In case a number of points is provided, which is not a square number, the number of points actually processed is set to the next larger square number [*]. Up till now in this case only the points up to the number provided would have been processed by the jobs generate with combineTools.py.

[*] https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/blob/74x-root6/src/MultiDimFit.cc#L554
