### PR TITLE
Allowing addition of additional attributes to objects

### DIFF
--- a/CombineTools/interface/Algorithm.h
+++ b/CombineTools/interface/Algorithm.h
@@ -54,6 +54,24 @@ void FilterContainingRgx(Input& in, Filter const& filter, Converter fn,
     return cond != ch::contains_rgx(rgx, fn(p));
   });
 }
+
+template <typename Input, typename Filter, typename Converter, typename Funcarg>
+void FilterContaining(Input& in, Filter const& filter, Converter fn, Funcarg arg,
+                      bool cond) {
+  boost::remove_erase_if(in, [&](typename Input::value_type const& p) {
+    return cond != ch::contains(filter, fn(p,arg));
+  });
+}
+
+template <typename Input, typename Filter, typename Converter, typename Funcarg>
+void FilterContainingRgx(Input& in, Filter const& filter, Converter fn, Funcarg arg,
+                         bool cond) {
+  std::vector<boost::regex> rgx;
+  for (auto const& ele : filter) rgx.emplace_back(ele);
+  boost::remove_erase_if(in, [&](typename Input::value_type const& p) {
+    return cond != ch::contains_rgx(rgx, fn(p,arg));
+  });
+}
 }
 
 #endif

--- a/CombineTools/interface/CombineHarvester.h
+++ b/CombineTools/interface/CombineHarvester.h
@@ -145,6 +145,7 @@ class CombineHarvester {
   CombineHarvester& era(std::vector<std::string> const& vec, bool cond = true);
   CombineHarvester& channel(std::vector<std::string> const& vec, bool cond = true);
   CombineHarvester& mass(std::vector<std::string> const& vec, bool cond = true);
+  CombineHarvester& attr(std::vector<std::string> const& vec,std::string attr_label, bool cond = true);
   CombineHarvester& syst_name(std::vector<std::string> const& vec, bool cond = true);
   CombineHarvester& syst_type(std::vector<std::string> const& vec, bool cond = true);
 

--- a/CombineTools/interface/Object.h
+++ b/CombineTools/interface/Object.h
@@ -1,6 +1,7 @@
 #ifndef CombineTools_Object_h
 #define CombineTools_Object_h
 #include <string>
+#include <map>
 
 namespace ch {
 
@@ -36,6 +37,11 @@ class Object {
   virtual void set_mass(std::string const& mass) { mass_ = mass; }
   virtual std::string const& mass() const { return mass_; }
 
+  virtual void set_attribute(std::string const& attr_label, std::string const& attr_value);
+  virtual void delete_attribute(std::string const& attr_label) { attributes_.erase(attr_label); }
+  virtual std::map<std::string,std::string> const& all_attributes() const { return attributes_;}
+  virtual std::string const& attribute(std::string const& attr_label) const { return attributes_.count(attr_label) >0 ? attributes_.at(attr_label) : attr_label ; }
+
  private:
   std::string bin_;
   std::string process_;
@@ -45,6 +51,7 @@ class Object {
   std::string channel_;
   int bin_id_;
   std::string mass_;
+  std::map<std::string,std::string> attributes_;
   friend void swap(Object& first, Object& second);
 };
 }

--- a/CombineTools/interface/Object.h
+++ b/CombineTools/interface/Object.h
@@ -40,7 +40,7 @@ class Object {
   virtual void set_attribute(std::string const& attr_label, std::string const& attr_value);
   virtual void delete_attribute(std::string const& attr_label) { attributes_.erase(attr_label); }
   virtual std::map<std::string,std::string> const& all_attributes() const { return attributes_;}
-  virtual std::string const& attribute(std::string const& attr_label) const { return attributes_.count(attr_label) >0 ? attributes_.at(attr_label) : attr_label ; }
+  virtual std::string const attribute(std::string const& attr_label) const { return attributes_.count(attr_label) >0 ? attributes_.at(attr_label) : "" ; }
 
  private:
   std::string bin_;

--- a/CombineTools/src/CombineHarvester_Creation.cc
+++ b/CombineTools/src/CombineHarvester_Creation.cc
@@ -88,6 +88,10 @@ void CombineHarvester::AddSystFromProc(Process const& proc,
   boost::replace_all(subbed_name, "$ERA", proc.era());
   boost::replace_all(subbed_name, "$CHANNEL", proc.channel());
   boost::replace_all(subbed_name, "$ANALYSIS", proc.analysis());
+  std::map<std::string,std::string> attrs = proc.all_attributes();
+  for( const auto it : attrs){
+      boost::replace_all(subbed_name, "$ATTR("+it.first+")",proc.attribute(it.first));
+  }
   auto sys = std::make_shared<Systematic>();
   ch::SetProperties(sys.get(), &proc);
   sys->set_name(subbed_name);
@@ -117,6 +121,9 @@ void CombineHarvester::AddSystFromProc(Process const& proc,
       boost::replace_all(subbed_args, "$ERA", proc.era());
       boost::replace_all(subbed_args, "$CHANNEL", proc.channel());
       boost::replace_all(subbed_args, "$ANALYSIS", proc.analysis());
+      for( const auto it : attrs){
+          boost::replace_all(subbed_args, "$ATTR("+it.first+")",proc.attribute(it.first));
+      }
       SetupRateParamFunc(subbed_name, formula, subbed_args);
     }
   }

--- a/CombineTools/src/CombineHarvester_Filters.cc
+++ b/CombineTools/src/CombineHarvester_Filters.cc
@@ -108,6 +108,21 @@ CombineHarvester& CombineHarvester::mass(
   return *this;
 }
 
+CombineHarvester& CombineHarvester::attr(
+    std::vector<std::string> const& vec, std::string attr_label, bool cond) {
+  if (GetFlag("filters-use-regex")) {
+    FilterContainingRgx(procs_, vec, std::mem_fn(&Process::attribute), attr_label, cond);
+    FilterContainingRgx(obs_, vec, std::mem_fn(&Observation::attribute), attr_label, cond);
+    FilterContainingRgx(systs_, vec, std::mem_fn(&Systematic::attribute), attr_label, cond);
+  } else {
+    FilterContaining(procs_, vec, std::mem_fn(&Process::attribute), attr_label, cond);
+    FilterContaining(obs_, vec, std::mem_fn(&Observation::attribute), attr_label, cond);
+    FilterContaining(systs_, vec, std::mem_fn(&Systematic::attribute), attr_label, cond);  
+  }
+  return *this;
+}
+
+
 CombineHarvester& CombineHarvester::syst_name(
     std::vector<std::string> const& vec, bool cond) {
   if (GetFlag("filters-use-regex")) {

--- a/CombineTools/src/Object.cc
+++ b/CombineTools/src/Object.cc
@@ -25,6 +25,7 @@ void swap(Object& first, Object& second) {
   swap(first.channel_, second.channel_);
   swap(first.bin_id_, second.bin_id_);
   swap(first.mass_, second.mass_);
+  swap(first.attributes_, second.attributes_);
 }
 
 Object::Object(Object const& other)
@@ -35,7 +36,8 @@ Object::Object(Object const& other)
       era_(other.era_),
       channel_(other.channel_),
       bin_id_(other.bin_id_),
-      mass_(other.mass_) {
+      mass_(other.mass_),
+      attributes_(other.attributes_) {
 }
 
 Object::Object(Object&& other)

--- a/CombineTools/src/Object.cc
+++ b/CombineTools/src/Object.cc
@@ -50,6 +50,14 @@ Object::Object(Object&& other)
   swap(*this, other);
 }
 
+void Object::set_attribute(std::string const& attr_label, std::string const& attr_value){
+    if(attributes_.count(attr_label)>0){
+        attributes_[attr_label]=attr_value;
+    } else {
+        attributes_.insert(std::pair<std::string,std::string>(attr_label,attr_value));
+    }
+}
+
 Object& Object::operator=(Object other) {
   swap(*this, other);
   return (*this);


### PR DESCRIPTION
This provides methods to add extra attributes (on top of the defaults like bin, channel, era, etc.). Any number of attributes can be added by calling the set_attribute function. Pattern replacement and filtering methods for these additional attributes have also been added.