### PR TITLE
Fix compilation error with gcc530

### DIFF
--- a/CombinePdfs/bin/SMLegacyMorphing.cpp
+++ b/CombinePdfs/bin/SMLegacyMorphing.cpp
@@ -248,7 +248,7 @@ int main() {
       for (auto bin : bins) {
         for (auto p : sig_procs) {
           ch::BuildRooMorphing(ws, cb, bin, p, mh, "norm",
-                               can_morph[chn], true, nullptr /*&demo*/);
+                               can_morph[chn], true, false, nullptr /*&demo*/);
         }
       }
     }


### PR DESCRIPTION
I moved to CMSSW_8_1_0, slc6_amd64_gcc530 and the latest version of combine, and got this compiler error:
```
/home/users/p/d/pdavid/ttW/stat/CMSSW_8_1_0/src/CombineHarvester/CombinePdfs/bin/SMLegacyMorphing.cpp: In function 'int main()':
/home/users/p/d/pdavid/ttW/stat/CMSSW_8_1_0/src/CombineHarvester/CombinePdfs/bin/SMLegacyMorphing.cpp:251:71: error: converting to 'bool' from 'std::nullptr_t' requires direct-initialization [-fpermissive]
                                can_morph[chn], true, nullptr /*&demo*/);
                                                                       ^
In file included from /home/users/p/d/pdavid/ttW/stat/CMSSW_8_1_0/src/CombineHarvester/CombinePdfs/bin/SMLegacyMorphing.cpp:12:0:
/home/users/p/d/pdavid/ttW/stat/CMSSW_8_1_0/src/CombineHarvester/CombinePdfs/interface/MorphFunctions.h:35:6: note:   initializing argument 9 of 'void ch::BuildRooMorphing(RooWorkspace&, ch::CombineHarvester&, con
st string&, const string&, RooAbsReal&, std::string, bool, bool, bool, TFile*)'
 void BuildRooMorphing(RooWorkspace& ws, CombineHarvester& cb,
      ^
config/SCRAM/GMake/Makefile.rules:1965: recipe for target 'tmp/slc6_amd64_gcc530/src/CombineHarvester/CombinePdfs/bin/SMLegacyMorphing/SMLegacyMorphing.o' failed
```
the fix is trivial (`false` and `nullptr` are the default values of the last two arguments)