### PR TITLE
Mt tot y splitting

### DIFF
--- a/CombineTools/python/plotting.py
+++ b/CombineTools/python/plotting.py
@@ -1468,8 +1468,8 @@ def isclose(a, b, rel_tol=1e-9, abs_tol=0.0):
 
 def StyleLimitBand(graph_dict, overwrite_style_dict=None):
     style_dict = {
-            'obs' : { 'LineWidth' : 2, 'LineColor' : R.kBlack, 'LineStyle' : 1},
-            'exp0' : { 'LineWidth' : 2, 'LineColor' : R.kBlack, 'LineStyle' : 2},
+            'obs' : { 'LineWidth' : 2},
+            'exp0' : { 'LineWidth' : 2, 'LineColor' : R.kRed},
             'exp1' : { 'FillColor' : R.kGreen},
             'exp2' : { 'FillColor' : R.kYellow}
             }

--- a/CombineTools/python/plotting.py
+++ b/CombineTools/python/plotting.py
@@ -328,6 +328,23 @@ def TwoPadSplit(split_point, gap_low, gap_high):
     result = [upper, lower]
     return result
 
+def ThreePadSplit(upper_split_point, split_point, gap_low, gap_high):
+    upper2 = R.TPad('upper2', 'upper2', 0., 0., 1., 1.)
+    upper2.SetTopMargin(1 - upper_split_point)
+    upper2.SetBottomMargin(split_point + gap_high)
+    upper2.SetFillStyle(4000)
+    #upper2.Draw()
+    upper1 = R.TPad('upper1', 'upper1', 0., 0., 1., 1.)
+    upper1.SetBottomMargin(upper_split_point)
+    upper1.SetFillStyle(4000)
+    upper1.Draw()
+    lower = R.TPad('lower', 'lower', 0., 0., 1., 1.)
+    lower.SetTopMargin(1 - split_point + gap_low)
+    lower.SetFillStyle(4000)
+    #lower.Draw()
+    upper1.cd()
+    result = [upper1, lower, upper2]
+    return result
 
 def MultiRatioSplit(split_points, gaps_low, gaps_high):
     """Create a set of TPads split vertically on the TCanvas
@@ -1451,8 +1468,8 @@ def isclose(a, b, rel_tol=1e-9, abs_tol=0.0):
 
 def StyleLimitBand(graph_dict, overwrite_style_dict=None):
     style_dict = {
-            'obs' : { 'LineWidth' : 2},
-            'exp0' : { 'LineWidth' : 2, 'LineColor' : R.kRed},
+            'obs' : { 'LineWidth' : 2, 'LineColor' : R.kBlack, 'LineStyle' : 1},
+            'exp0' : { 'LineWidth' : 2, 'LineColor' : R.kBlack, 'LineStyle' : 2},
             'exp1' : { 'FillColor' : R.kGreen},
             'exp2' : { 'FillColor' : R.kYellow}
             }

--- a/CombineTools/python/plotting.py
+++ b/CombineTools/python/plotting.py
@@ -333,7 +333,7 @@ def ThreePadSplit(upper_split_point, split_point, gap_low, gap_high):
     upper2.SetTopMargin(1 - upper_split_point)
     upper2.SetBottomMargin(split_point + gap_high)
     upper2.SetFillStyle(4000)
-    #upper2.Draw()
+    upper2.Draw()
     upper1 = R.TPad('upper1', 'upper1', 0., 0., 1., 1.)
     upper1.SetBottomMargin(upper_split_point)
     upper1.SetFillStyle(4000)
@@ -341,7 +341,7 @@ def ThreePadSplit(upper_split_point, split_point, gap_low, gap_high):
     lower = R.TPad('lower', 'lower', 0., 0., 1., 1.)
     lower.SetTopMargin(1 - split_point + gap_low)
     lower.SetFillStyle(4000)
-    #lower.Draw()
+    lower.Draw()
     upper1.cd()
     result = [upper1, lower, upper2]
     return result

--- a/MSSMFull2016/scripts/makeMassPlots_y-slitted.py
+++ b/MSSMFull2016/scripts/makeMassPlots_y-slitted.py
@@ -1,0 +1,250 @@
+import os
+
+CHN_DICT = {
+    "zmm": "Z#rightarrow#mu#mu CR",
+    "ttbar": "t#bar{t} CR",
+    "et": "e_{}#tau_{h}",
+    "mt": "#mu_{}#tau_{h}",
+    "em": "e#mu",
+    "tt": "#tau_{h}#tau_{h}"
+}
+
+CAT_DICT_EMT = {
+    "8": "No B-tag Tight-^{}m_{T}",
+    "9": "B-tag Tight-^{}m_{T}",
+    "10": "No B-tag Loose-^{}m_{T}",
+    "11": "B-tag Loose-^{}m_{T}"
+}
+
+CAT_DICT_TT = {
+    "8": "No B-tag",
+    "9": "B-tag"
+}
+
+CAT_DICT_EM = {
+    "8": "No B-tag Low-^{}D_{#zeta}",
+    "9": "B-tag Low-^{}D_{#zeta}",
+    "10": "No B-tag Medium-^{}D_{#zeta}",
+    "11": "B-tag Medium-^{}D_{#zeta}",
+    "12": "No B-tag High-^{}D_{#zeta}",
+    "13": "B-tag High-^{}D_{#zeta}"
+}
+
+
+RANGE_DICT = {
+    "em" : 1E-5 ,
+    "et" : 5E-7 ,
+    "mt" : 1E-7 , 
+    "tt" : 1E-7 ,
+    "zmm" : 1E-3 
+}
+
+PAD_DICT = {
+    "em" : 0.42 ,
+    "et" : 0.45 ,
+    "mt" : 0.45 , 
+    "tt" : 0.5 
+}
+
+CAT_SPLIT_DICT_EMT = {
+    "mt" : {
+        "8": 200,
+        "9": 1,
+        "10": 200,
+        "11": 1
+    },
+    "et" : {
+        "8": 50,
+        "9": 1,
+        "10": 50,
+        "11": 1
+    }
+}
+
+CAT_SPLIT_DICT_EM = {
+    "8": 200,
+    "9": 1,
+    "10": 100,
+    "11": 1,
+    "12": 20,
+    "13": 1
+}
+
+CAT_SPLIT_DICT_TT = {
+    "8": 100,
+    "9": 1
+}
+
+CAT_RATIO_RANGE_DICT_EMT = {
+    "mt" : {
+        "8": "0.4,1.6",
+        "9": "0.4,1.6",
+        "10": "0.4,1.6",
+        "11": "0.4,1.6"
+    },
+    "et" : {
+        "8": "0.4,1.6",
+        "9": "0.4,1.6",
+        "10": "0.4,1.6",
+        "11": "0.4,1.6"
+    }
+}
+
+CAT_RATIO_RANGE_DICT_TT = {
+    "8": "0.4,1.6",
+    "9": "0.4,1.6"
+}
+
+# y splitted post-fit plots
+
+for MODE in ['postfit']:
+    for CHN in ['mt','et']:
+        for CAT in CAT_DICT_EMT:
+            LABEL = "%s %s" % (CHN_DICT[CHN], CAT_DICT_EMT[CAT])
+            SPLIT = "%s" % CAT_SPLIT_DICT_EMT[CHN][CAT]
+            YMIN = "%s" % RANGE_DICT[CHN]
+            PAD = "%s" % PAD_DICT[CHN]
+            RRANGE = "%s" % CAT_RATIO_RANGE_DICT_EMT[CHN][CAT]
+            os.system(('python CombineHarvester/MSSMFull2016/scripts/postFitPlotJetFakes.py' \
+                  ' --file=shapes.root --ratio --extra_pad="%(PAD)s" --model_dep --mA 700 --tanb 20' \
+                  ' --file_dir="htt_%(CHN)s_%(CAT)s" --custom_x_range --x_axis_min=0.1 --x_axis_max 4000 --log_x --log_y' \
+                  ' --ratio_range=%(RRANGE)s --y_splitted %(SPLIT)s --sb_vs_b_ratio' \
+                  ' --outname htt_%(CHN)s_%(CAT)s_splitted --mode %(MODE)s --custom_y_range --y_axis_min "%(YMIN)s" --y_axis_max 1E15' \
+                  ' --channel_label "%(LABEL)s" --empty_bin_error' % vars()))
+#            break
+#        break
+#    break
+
+for MODE in ['postfit']:
+    for CHN in ['em']:
+        for CAT in CAT_DICT_EM:
+            LABEL = "%s %s" % (CHN_DICT[CHN], CAT_DICT_EM[CAT])
+            SPLIT = "%s" % CAT_SPLIT_DICT_EM[CAT]
+            YMIN = "%s" % RANGE_DICT[CHN]
+            PAD = "%s" % PAD_DICT[CHN]
+            os.system(('python CombineHarvester/MSSMFull2016/scripts/postFitPlotJetFakes.py' \
+                  ' --file=shapes.root --ratio --extra_pad="%(PAD)s" --model_dep --mA 700 --tanb 20' \
+                  ' --file_dir="htt_%(CHN)s_%(CAT)s" --custom_x_range --x_axis_min=0.1 --x_axis_max 4000 --log_x --log_y' \
+                  ' --ratio_range=0.4,1.6 --y_splitted %(SPLIT)s --sb_vs_b_ratio' \
+                  ' --outname htt_%(CHN)s_%(CAT)s_splitted --mode %(MODE)s --custom_y_range --y_axis_min "%(YMIN)s" --y_axis_max 1E20' \
+                  ' --channel_label "%(LABEL)s" --empty_bin_error' % vars()))
+
+for MODE in ['postfit']:
+    for CHN in ['tt']:
+        for CAT in CAT_DICT_TT:
+            LABEL = "%s %s" % (CHN_DICT[CHN], CAT_DICT_TT[CAT])
+            SPLIT = "%s" % CAT_SPLIT_DICT_TT[CAT]
+            YMIN = "%s" % RANGE_DICT[CHN]
+            PAD = "%s" % PAD_DICT[CHN]
+            RRANGE = "%s" % CAT_RATIO_RANGE_DICT_TT[CAT]
+            os.system(('python CombineHarvester/MSSMFull2016/scripts/postFitPlotJetFakes.py' \
+                  ' --file=shapes.root --ratio --extra_pad="%(PAD)s" --model_dep --mA 700 --tanb 20' \
+                  ' --file_dir="htt_%(CHN)s_%(CAT)s" --custom_x_range --x_axis_min=0.1 --x_axis_max 4000 --log_x --log_y' \
+                  ' --ratio_range=%(RRANGE)s --y_splitted %(SPLIT)s --sb_vs_b_ratio' \
+                  ' --outname htt_%(CHN)s_%(CAT)s_splitted --mode %(MODE)s --custom_y_range --y_axis_min "%(YMIN)s" --y_axis_max 1E20' \
+                  ' --channel_label "%(LABEL)s" --empty_bin_error' % vars()))
+
+
+# y-splitted pre-fit plots
+for MODE in ['prefit']:
+    for CHN in ['mt','et']:
+        for CAT in CAT_DICT_EMT:
+            LABEL = "%s %s" % (CHN_DICT[CHN], CAT_DICT_EMT[CAT])
+            SPLIT = "%s" % CAT_SPLIT_DICT_EMT[CHN][CAT]
+            YMIN = "%s" % RANGE_DICT[CHN]
+            PAD = "%s" % PAD_DICT[CHN]
+            RRANGE = "%s" % CAT_RATIO_RANGE_DICT_EMT[CHN][CAT]
+            os.system(('python CombineHarvester/MSSMFull2016/scripts/postFitPlotJetFakes.py' \
+                  ' --file=shapes.root --ratio --extra_pad="%(PAD)s" --no_signal' \
+                  ' --file_dir="htt_%(CHN)s_%(CAT)s" --custom_x_range --x_axis_min=0.1 --x_axis_max 4000 --log_x --log_y' \
+                  ' --ratio_range=%(RRANGE)s --y_splitted %(SPLIT)s' \
+                  ' --outname htt_%(CHN)s_%(CAT)s_splitted --mode %(MODE)s --custom_y_range --y_axis_min "%(YMIN)s" --y_axis_max 1E15' \
+                  ' --channel_label "%(LABEL)s" --empty_bin_error' % vars()))
+
+for MODE in ['prefit']:
+    for CHN in ['em']:
+        for CAT in CAT_DICT_EM:
+            LABEL = "%s %s" % (CHN_DICT[CHN], CAT_DICT_EM[CAT])
+            SPLIT = "%s" % CAT_SPLIT_DICT_EM[CAT]
+            YMIN = "%s" % RANGE_DICT[CHN]
+            PAD = "%s" % PAD_DICT[CHN]
+            os.system(('python CombineHarvester/MSSMFull2016/scripts/postFitPlotJetFakes.py' \
+                  ' --file=shapes.root --ratio --extra_pad="%(PAD)s" --no_signal' \
+                  ' --file_dir="htt_%(CHN)s_%(CAT)s" --custom_x_range --x_axis_min=0.1 --x_axis_max 4000 --log_x --log_y' \
+                  ' --ratio_range=0.4,1.6 --y_splitted %(SPLIT)s' \
+                  ' --outname htt_%(CHN)s_%(CAT)s_splitted --mode %(MODE)s --custom_y_range --y_axis_min "%(YMIN)s" --y_axis_max 1E20' \
+                  ' --channel_label "%(LABEL)s" --empty_bin_error' % vars()))
+
+for MODE in ['prefit']:
+    for CHN in ['tt']:
+        for CAT in CAT_DICT_TT:
+            LABEL = "%s %s" % (CHN_DICT[CHN], CAT_DICT_TT[CAT])
+            SPLIT = "%s" % CAT_SPLIT_DICT_TT[CAT]
+            YMIN = "%s" % RANGE_DICT[CHN]
+            PAD = "%s" % PAD_DICT[CHN]
+            RRANGE = "%s" % CAT_RATIO_RANGE_DICT_TT[CAT]
+            os.system(('python CombineHarvester/MSSMFull2016/scripts/postFitPlotJetFakes.py' \
+                  ' --file=shapes.root --ratio --extra_pad="%(PAD)s" --no_signal' \
+                  ' --file_dir="htt_%(CHN)s_%(CAT)s" --custom_x_range --x_axis_min=0.1 --x_axis_max 4000 --log_x --log_y' \
+                  ' --ratio_range=%(RRANGE)s --y_splitted %(SPLIT)s' \
+                  ' --outname htt_%(CHN)s_%(CAT)s_splitted --mode %(MODE)s --custom_y_range --y_axis_min "%(YMIN)s" --y_axis_max 1E20' \
+                  ' --channel_label "%(LABEL)s" --empty_bin_error' % vars()))
+
+for MODE in ['prefit']:
+    for CHN in ['zmm']:
+        for CAT in CAT_DICT_TT:
+            LABEL = "%s %s" % (CHN_DICT[CHN], CAT_DICT_TT[CAT])
+            YMIN = "%s" % RANGE_DICT[CHN]
+            PAD = "%s" % PAD_DICT["tt"]
+            os.system(('python CombineHarvester/MSSMFull2016/scripts/postFitPlotJetFakes.py' \
+                  ' --file=shapes.root --ratio --extra_pad="%(PAD)s" --no_signal' \
+                  ' --file_dir="htt_%(CHN)s_%(CAT)s" --custom_x_range --x_axis_min=0 --x_axis_max 1 --log_y' \
+                  ' --ratio_range=0.92,1.08 --channel zmm --x_title "counting experiment for ^{}m_{#mu#mu}"' \
+                  ' --outname htt_%(CHN)s_%(CAT)s --mode %(MODE)s --custom_y_range --y_axis_min "%(YMIN)s"' \
+                  ' --channel_label "%(LABEL)s" --empty_bin_error' % vars()))
+
+# standard plots
+for MODE in ['postfit']:
+    for CHN in ['mt','et']:
+        for CAT in CAT_DICT_EMT:
+            LABEL = "%s %s" % (CHN_DICT[CHN], CAT_DICT_EMT[CAT])
+            SPLIT = "%s" % CAT_SPLIT_DICT_EMT[CHN][CAT]
+            YMIN = "%s" % RANGE_DICT[CHN]
+            PAD = "%s" % PAD_DICT[CHN]
+            RRANGE = "%s" % CAT_RATIO_RANGE_DICT_EMT[CHN][CAT]
+            os.system(('python CombineHarvester/MSSMFull2016/scripts/postFitPlotJetFakes.py' \
+                  ' --file=shapes.root --ratio --extra_pad="%(PAD)s" --model_dep --mA 700 --tanb 20' \
+                  ' --file_dir="htt_%(CHN)s_%(CAT)s" --custom_x_range --x_axis_min=0.1 --x_axis_max 4000 --log_x --log_y' \
+                  ' --ratio_range=%(RRANGE)s  --sb_vs_b_ratio' \
+                  ' --outname htt_%(CHN)s_%(CAT)s --mode %(MODE)s --custom_y_range --y_axis_min "%(YMIN)s" --y_axis_max 1E15' \
+                  ' --channel_label "%(LABEL)s" --empty_bin_error' % vars()))
+
+for MODE in ['postfit']:
+    for CHN in ['em']:
+        for CAT in CAT_DICT_EM:
+            LABEL = "%s %s" % (CHN_DICT[CHN], CAT_DICT_EM[CAT])
+            SPLIT = "%s" % CAT_SPLIT_DICT_EM[CAT]
+            YMIN = "%s" % RANGE_DICT[CHN]
+            PAD = "%s" % PAD_DICT[CHN]
+            os.system(('python CombineHarvester/MSSMFull2016/scripts/postFitPlotJetFakes.py' \
+                  ' --file=shapes.root --ratio --extra_pad="%(PAD)s" --model_dep --mA 700 --tanb 20' \
+                  ' --file_dir="htt_%(CHN)s_%(CAT)s" --custom_x_range --x_axis_min=0.1 --x_axis_max 4000 --log_x --log_y' \
+                  ' --ratio_range=0.4,1.6 --sb_vs_b_ratio' \
+                  ' --outname htt_%(CHN)s_%(CAT)s --mode %(MODE)s --custom_y_range --y_axis_min "%(YMIN)s" --y_axis_max 1E20' \
+                  ' --channel_label "%(LABEL)s" --empty_bin_error' % vars()))
+
+for MODE in ['postfit']:
+    for CHN in ['tt']:
+        for CAT in CAT_DICT_TT:
+            LABEL = "%s %s" % (CHN_DICT[CHN], CAT_DICT_TT[CAT])
+            SPLIT = "%s" % CAT_SPLIT_DICT_TT[CAT]
+            YMIN = "%s" % RANGE_DICT[CHN]
+            PAD = "%s" % PAD_DICT[CHN]
+            RRANGE = "%s" % CAT_RATIO_RANGE_DICT_TT[CAT]
+            os.system(('python CombineHarvester/MSSMFull2016/scripts/postFitPlotJetFakes.py' \
+                  ' --file=shapes.root --ratio --extra_pad="%(PAD)s" --model_dep --mA 700 --tanb 20' \
+                  ' --file_dir="htt_%(CHN)s_%(CAT)s" --custom_x_range --x_axis_min=0.1 --x_axis_max 4000 --log_x --log_y' \
+                  ' --ratio_range=%(RRANGE)s --sb_vs_b_ratio' \
+                  ' --outname htt_%(CHN)s_%(CAT)s --mode %(MODE)s --custom_y_range --y_axis_min "%(YMIN)s" --y_axis_max 1E20' \
+                  ' --channel_label "%(LABEL)s" --empty_bin_error' % vars()))
+

--- a/MSSMFull2016/scripts/makeMassPlots_y-slitted.py
+++ b/MSSMFull2016/scripts/makeMassPlots_y-slitted.py
@@ -199,7 +199,7 @@ for MODE in ['prefit']:
             os.system(('python CombineHarvester/MSSMFull2016/scripts/postFitPlotJetFakes.py' \
                   ' --file=shapes.root --ratio --extra_pad="%(PAD)s" --no_signal' \
                   ' --file_dir="htt_%(CHN)s_%(CAT)s" --custom_x_range --x_axis_min=0 --x_axis_max 1 --log_y' \
-                  ' --ratio_range=0.92,1.08 --channel zmm --x_title "counting experiment for ^{}m_{#mu#mu}"' \
+                  ' --ratio_range=0.92,1.08 --channel zmm --x_title "counting experiment" --y_title "Events" ' \
                   ' --outname htt_%(CHN)s_%(CAT)s --mode %(MODE)s --custom_y_range --y_axis_min "%(YMIN)s"' \
                   ' --channel_label "%(LABEL)s" --empty_bin_error' % vars()))
 

--- a/MSSMFull2016/scripts/plotMSSMLimits.py
+++ b/MSSMFull2016/scripts/plotMSSMLimits.py
@@ -46,6 +46,8 @@ parser.add_argument(
     '--higgs-injected', action='store_true', help="""Draw with style for higgs injected (blue bands)""")
 parser.add_argument(
     '--plot-exp-points', action='store_true', help="""Plot markers instead of just a line for the expected limit""")
+parser.add_argument(
+    '--use-hig-17-020-style', action='store_true', help="""Plot a dashed black line for the expected limit as in hig-17-020""")
 parser.add_argument('--table_vals', help='Amount of values to be written in a table for different masses', default=10)
 args = parser.parse_args()
 
@@ -79,6 +81,14 @@ style_dict_inj = {
             }
         }
 
+style_dict_hig_17_020 = {
+        'style' : {
+            'exp0' : { 'LineColor' : ROOT.kBlack, 'LineStyle' : 2}
+            },
+        'legend' : {
+            }
+        }
+
 style_dict=None
 if args.higgs_bg:
     style_dict = style_dict_bg
@@ -86,6 +96,8 @@ if args.higgs_injected:
     style_dict = style_dict_inj
 if args.plot_exp_points:
     style_dict = style_dict_exponly
+if args.use_hig_17_020_style:
+    style_dict = style_dict_hig_17_020
 
 def DrawAxisHists(pads, axis_hists, def_pad=None):
     for i, pad in enumerate(pads):
@@ -157,7 +169,7 @@ for src in args.input:
         if axis is None:
             axis = plot.CreateAxisHists(len(pads), graph_sets[-1].values()[0], True)
             DrawAxisHists(pads, axis, pads[0])
-        if args.higgs_bg or args.higgs_injected or args.plot_exp_points:
+        if args.higgs_bg or args.higgs_injected or args.plot_exp_points or args.use_hig_17_020_style:
             plot.StyleLimitBand(graph_sets[-1],overwrite_style_dict=style_dict["style"])
             plot.DrawLimitBand(pads[0], graph_sets[-1], legend=legend,legend_overwrite=style_dict["legend"])
         else:

--- a/MSSMFull2016/scripts/postFitPlotJetFakes.py
+++ b/MSSMFull2016/scripts/postFitPlotJetFakes.py
@@ -107,6 +107,7 @@ parser.add_argument('--uniform_binning', default=False, action='store_true', hel
 parser.add_argument('--ratio_range',  help='y-axis range for ratio plot in format MIN,MAX', default="0.7,1.3")
 parser.add_argument('--no_signal', action='store_true',help='Do not draw signal')
 parser.add_argument('--y_splitted', default=0.0,type=float,help='Use splitted y axis with linear at top and log scale at bottom. Cannot be used together with bkg_frac_ratios')
+parser.add_argument('--sb_vs_b_ratio', action='store_true',help='Draw a Signal + Background / Background into the ratio plot')
 parser.add_argument('--x_title', default='m_{T}^{tot} (GeV)',help='Title for the x-axis')
 parser.add_argument('--y_title', default='dN/dm_{T}^{tot} (1/GeV)',help='Title for the y-axis')
 parser.add_argument('--lumi', default='35.9 fb^{-1} (13 TeV)',help='Lumi label')
@@ -144,6 +145,7 @@ log_x=args.log_x
 fractions=args.bkg_fractions
 frac_ratios=args.bkg_frac_ratios
 y_splitted=args.y_splitted
+sb_vs_b_ratio = args.sb_vs_b_ratio
 uniform=args.uniform_binning
 #If plotting bkg fractions don't want to use log scale on y axis
 if fractions:
@@ -225,20 +227,20 @@ if not args.postfitshapes:
 histo_file = ROOT.TFile(shape_file)
 
 #Store plotting information for different backgrounds 
-background_schemes = {'mt':[backgroundComp("t#bar{t}",["TTT"],ROOT.TColor.GetColor(155,152,204)),backgroundComp("Electroweak",["VVT"],ROOT.TColor.GetColor(222,90,106)),backgroundComp("Z#rightarrow#mu#mu",["ZL"],ROOT.TColor.GetColor(100,192,232)),backgroundComp("Z#rightarrow#tau#tau",["ZTT"],ROOT.TColor.GetColor(248,206,104)),backgroundComp("jet#rightarrow#tau_{h} fakes",["jetFakes"],ROOT.TColor.GetColor(192,232,100))],
-'et':[backgroundComp("t#bar{t}",["TTT"],ROOT.TColor.GetColor(155,152,204)),backgroundComp("Electroweak",["VVT"],ROOT.TColor.GetColor(222,90,106)),backgroundComp("Z#rightarrowee",["ZL"],ROOT.TColor.GetColor(100,192,232)),backgroundComp("Z#rightarrow#tau#tau",["ZTT"],ROOT.TColor.GetColor(248,206,104)),backgroundComp("jet#rightarrow#tau_{h} fakes",["jetFakes"],ROOT.TColor.GetColor(192,232,100))],
-'tt':[backgroundComp("t#bar{t}",["TTT"],ROOT.TColor.GetColor(155,152,204)),backgroundComp("Electroweak",["VVT","ZL"],ROOT.TColor.GetColor(222,90,106)),backgroundComp("Z#rightarrow#tau#tau",["ZTT"],ROOT.TColor.GetColor(248,206,104)),backgroundComp("jet#rightarrow#tau_{h} fakes",["jetFakes"],ROOT.TColor.GetColor(192,232,100))],
+background_schemes = {'mt':[backgroundComp("t#bar{t}",["TTT"],ROOT.TColor.GetColor(155,152,204)),backgroundComp("Electroweak",["VVT"],ROOT.TColor.GetColor(222,90,106)),backgroundComp("Z#rightarrow#mu#mu",["ZL"],ROOT.TColor.GetColor(100,192,232)),backgroundComp("jet#rightarrow#tau_{h} fakes",["jetFakes"],ROOT.TColor.GetColor(192,232,100)),backgroundComp("Z#rightarrow#tau#tau",["ZTT"],ROOT.TColor.GetColor(248,206,104))],
+'et':[backgroundComp("t#bar{t}",["TTT"],ROOT.TColor.GetColor(155,152,204)),backgroundComp("Electroweak",["VVT"],ROOT.TColor.GetColor(222,90,106)),backgroundComp("Z#rightarrowee",["ZL"],ROOT.TColor.GetColor(100,192,232)),backgroundComp("jet#rightarrow#tau_{h} fakes",["jetFakes"],ROOT.TColor.GetColor(192,232,100)),backgroundComp("Z#rightarrow#tau#tau",["ZTT"],ROOT.TColor.GetColor(248,206,104))],
+'tt':[backgroundComp("t#bar{t}",["TTT"],ROOT.TColor.GetColor(155,152,204)),backgroundComp("Electroweak",["VVT","ZL"],ROOT.TColor.GetColor(222,90,106)),backgroundComp("jet#rightarrow#tau_{h} fakes",["jetFakes"],ROOT.TColor.GetColor(192,232,100)),backgroundComp("Z#rightarrow#tau#tau",["ZTT"],ROOT.TColor.GetColor(248,206,104))],
 'em':[backgroundComp("t#bar{t}",["TT"],ROOT.TColor.GetColor(155,152,204)),backgroundComp("QCD", ["QCD"], ROOT.TColor.GetColor(250,202,255)),backgroundComp("Electroweak",["VV","W"],ROOT.TColor.GetColor(222,90,106)),backgroundComp("Z#rightarrowll",["ZLL"],ROOT.TColor.GetColor(100,192,232)),backgroundComp("Z#rightarrow#tau#tau",["ZTT"],ROOT.TColor.GetColor(248,206,104))],
 'ttbar':[backgroundComp("QCD", ["QCD"], ROOT.TColor.GetColor(250,202,255)),backgroundComp("Electroweak",["VV","W"],ROOT.TColor.GetColor(222,90,106)),backgroundComp("Z#rightarrowll",["ZLL"],ROOT.TColor.GetColor(100,192,232)),backgroundComp("Z#rightarrow#tau#tau",["ZTT"],ROOT.TColor.GetColor(248,206,104)),backgroundComp("t#bar{t}",["TT"],ROOT.TColor.GetColor(155,152,204))],
 'zmm':[backgroundComp("Misidentified #mu", ["QCD"], ROOT.TColor.GetColor(250,202,255)),backgroundComp("t#bar{t}",["TT"],ROOT.TColor.GetColor(155,152,204)),backgroundComp("Electroweak",["VV","W"],ROOT.TColor.GetColor(222,90,106)),backgroundComp("Z#rightarrow#tau#tau",["ZTT"],ROOT.TColor.GetColor(248,206,104)),backgroundComp("Z#rightarrow#mu#mu",["ZLL"],ROOT.TColor.GetColor(100,192,232))]}
-
-
-print "BG plotting info stored!"
 
 #Extract relevent histograms from shape file
 [sighist,binname] = getHistogram(histo_file,'TotalSig', file_dir, mode, args.no_signal, log_x)
 if not model_dep: sighist_ggH = getHistogram(histo_file,'ggH',file_dir, mode, args.no_signal, log_x)[0]
 if not model_dep: sighist_bbH = getHistogram(histo_file,'bbH',file_dir, mode, args.no_signal, log_x)[0]
+if sb_vs_b_ratio:
+    sbhist = getHistogram(histo_file,'TotalProcs',file_dir, mode, args.no_signal, log_x)[0]
+    bkg_sb_vs_b_ratio_hist = getHistogram(histo_file,'TotalBkg',file_dir, mode, logx=log_x)[0]
 for i in range(0,sighist.GetNbinsX()):
   if sighist.GetBinContent(i) < y_axis_min: sighist.SetBinContent(i,y_axis_min)
 bkghist = getHistogram(histo_file,'TotalBkg',file_dir, mode, logx=log_x)[0]
@@ -422,7 +424,7 @@ if args.ratio:
   if frac_ratios:
     pads=plot.MultiRatioSplit([0.25,0.14],[0.01,0.01],[0.01,0.01])
   elif y_splitted:
-    pads=plot.ThreePadSplit(0.5,0.29,0.01,0.01)
+    pads=plot.ThreePadSplit(0.53,0.29,0.01,0.01)
   else:
     pads=plot.TwoPadSplit(0.29,0.01,0.01)
 else:
@@ -446,18 +448,19 @@ if args.ratio and not fractions:
     axish = createAxisHists(2,bkghist,bkghist.GetXaxis().GetXmin(),bkghist.GetXaxis().GetXmax()-0.01)
     axish[1].GetXaxis().SetTitle(args.x_title)
     axish[1].GetYaxis().SetNdivisions(4)
-    if not soverb_plot: axish[1].GetYaxis().SetTitle("Obs/Exp")
-    else: axish[1].GetYaxis().SetTitle("S/#sqrt(B)")
+    if soverb_plot: axish[1].GetYaxis().SetTitle("S/#sqrt(B)")
+    else: axish[1].GetYaxis().SetTitle("")
     #axish[1].GetYaxis().SetTitleSize(0.04)
     #axish[1].GetYaxis().SetLabelSize(0.04)
     #axish[1].GetYaxis().SetTitleOffset(1.3)
-    #axish[0].GetYaxis().SetTitleSize(0.04)
+    axish[0].GetYaxis().SetTitleSize(0.048)
     #axish[0].GetYaxis().SetLabelSize(0.04)
-    #axish[0].GetYaxis().SetTitleOffset(1.3)
+    axish[0].GetYaxis().SetTitleOffset(1.44)
     axish[0].GetXaxis().SetTitleSize(0)
     axish[0].GetXaxis().SetLabelSize(0)
     axish[0].GetXaxis().SetRangeUser(x_axis_min,bkghist.GetXaxis().GetXmax()-0.01)
     axish[1].GetXaxis().SetRangeUser(x_axis_min,bkghist.GetXaxis().GetXmax()-0.01)
+
     if custom_x_range:
       axish[0].GetXaxis().SetRangeUser(x_axis_min,x_axis_max-0.01)
       axish[1].GetXaxis().SetRangeUser(x_axis_min,x_axis_max-0.01)
@@ -474,6 +477,8 @@ if args.ratio and not fractions:
       axish[2].GetYaxis().SetRangeUser(y_axis_min, axistransit)
       axish[2].GetYaxis().SetTitle("")
       axish[2].GetYaxis().SetNdivisions(3)
+      width_sf = ((1-pads[0].GetTopMargin())-pads[0].GetBottomMargin())/((1-pads[2].GetTopMargin())-pads[2].GetBottomMargin())
+      axish[2].GetYaxis().SetTickLength(width_sf*axish[0].GetYaxis().GetTickLength())
 
   else :
     if(log_x):
@@ -521,6 +526,36 @@ if not custom_y_range:
   if(log_y): axish[0].SetMinimum(0.0009)
   else: axish[0].SetMinimum(0)
 
+hist_indices = [0,2] if y_splitted else [0]
+for i in hist_indices:
+    pads[i].cd()
+    axish[i].Draw("AXIS")
+
+    #Draw uncertainty band
+    bkghist.SetFillColor(plot.CreateTransparentColor(12,0.4))
+    bkghist.SetLineColor(0)
+    bkghist.SetMarkerSize(0)
+
+    stack.Draw("histsame")
+    #Don't draw total bkgs/signal if plotting bkg fractions
+    if not fractions and not uniform:
+      bkghist.Draw("e2same")
+      #Add signal, either model dependent or independent
+      if not args.no_signal and ((y_splitted and i == 2) or (not y_splitted)):
+        if model_dep is True: 
+          sighist.SetLineColor(ROOT.kGreen+3)
+          sighist.SetLineWidth(3)
+          sighist.Draw("histsame")
+        else: 
+          sighist_ggH.SetLineColor(ROOT.kBlue)
+          sighist_bbH.SetLineColor(ROOT.kBlue + 3)
+          sighist_ggH.SetLineWidth(3)
+          sighist_bbH.SetLineWidth(3)
+          sighist_ggH.Draw("histsame")
+          sighist_bbH.Draw("histsame")
+    if not soverb_plot and not fractions: 
+      blind_datahist.DrawCopy("e0x0same")
+    axish[i].Draw("axissame")
 
 hist_indices = [0,2] if y_splitted else [0]
 for i in hist_indices:
@@ -584,6 +619,8 @@ if not fractions:
         latex.DrawLatex(0.65,0.56,"#sigma(gg#phi)=%(r_ggH)s pb,"%vars())
         latex.DrawLatex(0.65,0.52,"#sigma(bb#phi)=%(r_bbH)s pb"%vars())
 if not args.bkg_fractions: legend.Draw("same")
+
+# Channel & Category label
 latex2 = ROOT.TLatex()
 latex2.SetNDC()
 latex2.SetTextAngle(0)
@@ -600,9 +637,8 @@ plot.DrawTitle(pads[0], args.lumi, 3)
 if args.ratio and not soverb_plot and not fractions:
   ratio_bkghist = plot.MakeRatioHist(bkghist,bkghist,True,False)
   blind_datahist = plot.MakeRatioHist(blind_datahist,bkghist,True,False)
-  #sb_hist = bkghist.Clone()
-  #sb_hist.Add(sighist_ggH.Clone())
-  #sb_hist = plot.MakeRatioHist(sb_hist,bkghist,True,False)
+  if sb_vs_b_ratio:
+    ratio_sbhist = plot.MakeRatioHist(sbhist,bkg_sb_vs_b_ratio_hist,True,False)
   if not frac_ratios:
     pads[1].cd()
     pads[1].SetGrid(0,1)
@@ -611,11 +647,21 @@ if args.ratio and not soverb_plot and not fractions:
     axish[1].SetMaximum(float(args.ratio_range.split(',')[1]))
     ratio_bkghist.SetMarkerSize(0)
     ratio_bkghist.Draw("e2same")
-    #sb_hist.SetMarkerSize(1)
-    #sb_hist.SetMarkerColor(ROOT.kBlue)
-    #sb_hist.Draw("same")
-    blind_datahist.DrawCopy("e0same")
+    if sb_vs_b_ratio:
+      ratio_sbhist.SetMarkerSize(0)
+      ratio_sbhist.SetLineColor(ROOT.kGreen+3)
+      ratio_sbhist.SetLineWidth(3)
+      ratio_sbhist.Draw("histsame][")
+    blind_datahist.DrawCopy("e0x0same")
     pads[1].RedrawAxis("G")
+      # Add also a ratio legend, since two relevant ratios shown
+    rlegend = plot.PositionedLegend(0.45,0.045,4,0.002)
+    rlegend.AddEntry(blind_datahist,"Obs/Bkg","PE")
+    if sb_vs_b_ratio:
+      rlegend.AddEntry(ratio_sbhist,"(Sig+Bkg)/Bkg","L")
+    rlegend.SetFillStyle(0)
+    rlegend.SetNColumns(2)
+    rlegend.Draw("same")
   else:
     pads[1].cd()
     axish[1].Draw("axis")
@@ -666,7 +712,7 @@ if y_splitted:
     x_min = axish[2].GetXaxis().GetXmin()
     x_max = axish[2].GetXaxis().GetXmax()
     splitline = ROOT.TLine(x_min,y_splitted,x_max,y_splitted)
-    splitline.SetLineWidth(2)
+    splitline.SetLineWidth(1)
     splitline.Draw()
     pads[0].cd()
     splitline.Draw()

--- a/MSSMFull2016/scripts/postFitPlotJetFakes.py
+++ b/MSSMFull2016/scripts/postFitPlotJetFakes.py
@@ -449,7 +449,8 @@ if args.ratio and not fractions:
     axish[1].GetXaxis().SetTitle(args.x_title)
     axish[1].GetYaxis().SetNdivisions(4)
     if soverb_plot: axish[1].GetYaxis().SetTitle("S/#sqrt(B)")
-    else: axish[1].GetYaxis().SetTitle("")
+    elif y_splitted or sb_vs_b_ratio: axish[1].GetYaxis().SetTitle("")
+    else: axish[1].GetYaxis().SetTitle("Obs/Exp")
     #axish[1].GetYaxis().SetTitleSize(0.04)
     #axish[1].GetYaxis().SetLabelSize(0.04)
     #axish[1].GetYaxis().SetTitleOffset(1.3)
@@ -624,14 +625,15 @@ if args.ratio and not soverb_plot and not fractions:
       ratio_sbhist.Draw("histsame][")
     blind_datahist.DrawCopy("e0x0same")
     pads[1].RedrawAxis("G")
-      # Add also a ratio legend, since two relevant ratios shown
-    rlegend = plot.PositionedLegend(0.45,0.045,4,0.002)
-    rlegend.AddEntry(blind_datahist,"Obs/Bkg","PE")
-    if sb_vs_b_ratio:
-      rlegend.AddEntry(ratio_sbhist,"(Sig+Bkg)/Bkg","L")
-    rlegend.SetFillStyle(0)
-    rlegend.SetNColumns(2)
-    rlegend.Draw("same")
+    if y_splitted or sb_vs_b_ratio:
+      # Add a ratio legend for y-splitted plots or plots with sb vs b ratios
+      rlegend = plot.PositionedLegend(0.45,0.045,4,0.002)
+      rlegend.AddEntry(blind_datahist,"Obs/Bkg","PE")
+      if sb_vs_b_ratio:
+        rlegend.AddEntry(ratio_sbhist,"(Sig+Bkg)/Bkg","L")
+      rlegend.SetFillStyle(0)
+      rlegend.SetNColumns(2)
+      rlegend.Draw("same")
   else:
     pads[1].cd()
     axish[1].Draw("axis")

--- a/MSSMFull2016/scripts/postFitPlotJetFakes.py
+++ b/MSSMFull2016/scripts/postFitPlotJetFakes.py
@@ -557,36 +557,6 @@ for i in hist_indices:
       blind_datahist.DrawCopy("e0x0same")
     axish[i].Draw("axissame")
 
-hist_indices = [0,2] if y_splitted else [0]
-for i in hist_indices:
-    pads[i].cd()
-    axish[i].Draw("AXIS")
-
-    #Draw uncertainty band
-    bkghist.SetFillColor(plot.CreateTransparentColor(12,0.4))
-    bkghist.SetLineColor(0)
-    bkghist.SetMarkerSize(0)
-
-    stack.Draw("histsame")
-    #Don't draw total bkgs/signal if plotting bkg fractions
-    if not fractions and not uniform:
-      bkghist.Draw("e2same")
-      #Add signal, either model dependent or independent
-      if not args.no_signal and ((y_splitted and i == 2) or (not y_splitted)):
-        if model_dep is True: 
-          sighist.SetLineColor(ROOT.kGreen+3)
-          sighist.SetLineWidth(3)
-          sighist.Draw("histsame")
-        else: 
-          sighist_ggH.SetLineColor(ROOT.kBlue)
-          sighist_bbH.SetLineColor(ROOT.kBlue + 3)
-          sighist_ggH.SetLineWidth(3)
-          sighist_bbH.SetLineWidth(3)
-          sighist_ggH.Draw("histsame")
-          sighist_bbH.Draw("histsame")
-    if not soverb_plot and not fractions: blind_datahist.DrawCopy("e0psame")
-    axish[i].Draw("axissame")
-
 pads[0].cd()
 #Setup legend
 legend = plot.PositionedLegend(0.30,0.30,3,0.03)
@@ -675,9 +645,6 @@ if args.ratio and not soverb_plot and not fractions:
     axish[2].SetMaximum(float(args.ratio_range.split(',')[1]))
     ratio_bkghist.SetMarkerSize(0)
     ratio_bkghist.Draw("e2same")
-    #sb_hist.SetMarkerSize(1)
-    #sb_hist.SetMarkerColor(ROOT.kBlue)
-    #sb_hist.Draw("same")
     blind_datahist.DrawCopy("e0same")
     pads[2].RedrawAxis("G")
     pads[1].RedrawAxis("G")

--- a/MSSMFull2016/scripts/postFitPlotJetFakes.py
+++ b/MSSMFull2016/scripts/postFitPlotJetFakes.py
@@ -106,8 +106,9 @@ parser.add_argument('--bkg_frac_ratios', default=False, action='store_true', hel
 parser.add_argument('--uniform_binning', default=False, action='store_true', help='Make plots in which each bin has the same width') 
 parser.add_argument('--ratio_range',  help='y-axis range for ratio plot in format MIN,MAX', default="0.7,1.3")
 parser.add_argument('--no_signal', action='store_true',help='Do not draw signal')
+parser.add_argument('--y_splitted', action='store_true',help='Use splitted y axis with linear at top and log scale at bottom. Cannot be used together with bkg_frac_ratios')
 parser.add_argument('--x_title', default='m_{T}^{tot} (GeV)',help='Title for the x-axis')
-parser.add_argument('--y_title', default='dN/dM_{T}^{tot} (1/GeV)',help='Title for the y-axis')
+parser.add_argument('--y_title', default='dN/dm_{T}^{tot} (1/GeV)',help='Title for the y-axis')
 parser.add_argument('--lumi', default='35.9 fb^{-1} (13 TeV)',help='Lumi label')
 
 
@@ -142,6 +143,7 @@ log_y=args.log_y
 log_x=args.log_x
 fractions=args.bkg_fractions
 frac_ratios=args.bkg_frac_ratios
+y_splitted=args.y_splitted
 uniform=args.uniform_binning
 #If plotting bkg fractions don't want to use log scale on y axis
 if fractions:
@@ -227,7 +229,11 @@ background_schemes = {'mt':[backgroundComp("t#bar{t}",["TTT"],ROOT.TColor.GetCol
 'et':[backgroundComp("t#bar{t}",["TTT"],ROOT.TColor.GetColor(155,152,204)),backgroundComp("Electroweak",["VVT"],ROOT.TColor.GetColor(222,90,106)),backgroundComp("Z#rightarrowee",["ZL"],ROOT.TColor.GetColor(100,192,232)),backgroundComp("Z#rightarrow#tau#tau",["ZTT"],ROOT.TColor.GetColor(248,206,104)),backgroundComp("jet#rightarrow#tau_{h} fakes",["jetFakes"],ROOT.TColor.GetColor(192,232,100))],
 'tt':[backgroundComp("t#bar{t}",["TTT"],ROOT.TColor.GetColor(155,152,204)),backgroundComp("Electroweak",["VVT","ZL"],ROOT.TColor.GetColor(222,90,106)),backgroundComp("Z#rightarrow#tau#tau",["ZTT"],ROOT.TColor.GetColor(248,206,104)),backgroundComp("jet#rightarrow#tau_{h} fakes",["jetFakes"],ROOT.TColor.GetColor(192,232,100))],
 'em':[backgroundComp("t#bar{t}",["TT"],ROOT.TColor.GetColor(155,152,204)),backgroundComp("QCD", ["QCD"], ROOT.TColor.GetColor(250,202,255)),backgroundComp("Electroweak",["VV","W"],ROOT.TColor.GetColor(222,90,106)),backgroundComp("Z#rightarrowll",["ZLL"],ROOT.TColor.GetColor(100,192,232)),backgroundComp("Z#rightarrow#tau#tau",["ZTT"],ROOT.TColor.GetColor(248,206,104))],
-'zm':[backgroundComp("Misidentified #mu", ["QCD"], ROOT.TColor.GetColor(250,202,255)),backgroundComp("t#bar{t}",["TT"],ROOT.TColor.GetColor(155,152,204)),backgroundComp("Electroweak",["VV","W","ZJ"],ROOT.TColor.GetColor(222,90,106)),backgroundComp("Z#rightarrow#tau#tau",["ZTT"],ROOT.TColor.GetColor(248,206,104)),backgroundComp("Z#rightarrow#mu#mu",["ZL"],ROOT.TColor.GetColor(100,192,232))]}
+'ttbar':[backgroundComp("QCD", ["QCD"], ROOT.TColor.GetColor(250,202,255)),backgroundComp("Electroweak",["VV","W"],ROOT.TColor.GetColor(222,90,106)),backgroundComp("Z#rightarrowll",["ZLL"],ROOT.TColor.GetColor(100,192,232)),backgroundComp("Z#rightarrow#tau#tau",["ZTT"],ROOT.TColor.GetColor(248,206,104)),backgroundComp("t#bar{t}",["TT"],ROOT.TColor.GetColor(155,152,204))],
+'zmm':[backgroundComp("Misidentified #mu", ["QCD"], ROOT.TColor.GetColor(250,202,255)),backgroundComp("t#bar{t}",["TT"],ROOT.TColor.GetColor(155,152,204)),backgroundComp("Electroweak",["VV","W"],ROOT.TColor.GetColor(222,90,106)),backgroundComp("Z#rightarrow#tau#tau",["ZTT"],ROOT.TColor.GetColor(248,206,104)),backgroundComp("Z#rightarrow#mu#mu",["ZLL"],ROOT.TColor.GetColor(100,192,232))]}
+
+
+print "BG plotting info stored!"
 
 #Extract relevent histograms from shape file
 [sighist,binname] = getHistogram(histo_file,'TotalSig', file_dir, mode, args.no_signal, log_x)
@@ -411,20 +417,56 @@ if frac_ratios:
 #Setup style related things
 c2 = ROOT.TCanvas()
 c2.cd()
+canvas_counter = 1 
+c2.SaveAs("{COUNTER}_canvas_initial.png".format(COUNTER=str(canvas_counter).zfill(3)))
+
 if args.ratio:
   if frac_ratios:
     pads=plot.MultiRatioSplit([0.25,0.14],[0.01,0.01],[0.01,0.01])
+  elif y_splitted:
+    upper_split_point = 0.5
+    split_point = 0.29
+    gap_high = 0.01
+    gap_low = 0.01
+    upper2 = ROOT.TPad('upper2', 'upper2', 0., 0., 1., 1.)
+    upper2.SetTopMargin(1 - upper_split_point)
+    upper2.SetBottomMargin(split_point + gap_high)
+    upper2.SetFillStyle(4000)
+    upper2.SetFrameLineWidth(0)
+    upper2.GetFrame().SetLineWidth(0)
+    #upper2.Draw()
+    upper1 = ROOT.TPad('upper1', 'upper1', 0., 0., 1., 1.)
+    upper1.SetBottomMargin(upper_split_point)
+    upper1.SetFillStyle(4000)
+    upper1.SetFrameLineWidth(0)
+    upper1.GetFrame().SetLineWidth(0)
+    upper1.Draw()
+    lower = ROOT.TPad('lower', 'lower', 0., 0., 1., 1.)
+    lower.SetTopMargin(1 - split_point + gap_low)
+    lower.SetFillStyle(4000)
+    #lower.Draw()
+    upper1.cd()
+    pads = [upper1, lower, upper2]
   else:
     pads=plot.TwoPadSplit(0.29,0.01,0.01)
 else:
   pads=plot.OnePad()
 pads[0].cd()
-if(log_y): pads[0].SetLogy(1)
-if(log_x): pads[0].SetLogx(1)
+if(log_y):
+  if y_splitted:
+    pads[2].SetLogy(1)
+  else:
+    pads[0].SetLogy(1)
+if(log_x):
+  pads[0].SetLogx(1)
+  if(y_splitted):
+    pads[2].SetLogx(1)
+
 if custom_x_range:
     if x_axis_max > bkghist.GetXaxis().GetXmax(): x_axis_max = bkghist.GetXaxis().GetXmax()
 if args.ratio and not fractions:
   if not frac_ratios:
+    print "not frac_ratios"
     if(log_x): pads[1].SetLogx(1)
     axish = createAxisHists(2,bkghist,bkghist.GetXaxis().GetXmin(),bkghist.GetXaxis().GetXmax()-0.01)
     axish[1].GetXaxis().SetTitle(args.x_title)
@@ -447,7 +489,21 @@ if args.ratio and not fractions:
     if custom_y_range:
       axish[0].GetYaxis().SetRangeUser(y_axis_min,y_axis_max)
       axish[1].GetYaxis().SetRangeUser(y_axis_min,y_axis_max)
+    if y_splitted:
+      axistransit=1.0
+      axish.append(axish[0].Clone())
+
+      axish[0].SetMinimum(axistransit)
+      axish[0].SetTickLength(0)
+      axish[0].GetXaxis().SetAxisColor(3,0.0)
+
+
+      axish[2].GetYaxis().SetRangeUser(y_axis_min, axistransit)
+      axish[2].GetYaxis().SetTitle("")
+      axish[2].GetYaxis().SetNdivisions(3, False)
+
   else :
+    print "frac ratios"
     if(log_x):
       pads[1].SetLogx(1)
       pads[2].SetLogx(1) 
@@ -477,6 +533,7 @@ if args.ratio and not fractions:
     if custom_y_range:
       axish[0].GetYaxis().SetRangeUser(y_axis_min,y_axis_max)
 else:
+  print "not ratio or fractions"
   axish = createAxisHists(1,bkghist,bkghist.GetXaxis().GetXmin(),bkghist.GetXaxis().GetXmax()-0.01)
 #  axish[0].GetYaxis().SetTitleOffset(1.4)
   if custom_x_range:
@@ -492,34 +549,56 @@ if not custom_y_range: axish[0].SetMaximum(extra_pad*bkghist.GetMaximum())
 if not custom_y_range: 
   if(log_y): axish[0].SetMinimum(0.0009)
   else: axish[0].SetMinimum(0)
-axish[0].Draw()
-
-#Draw uncertainty band
-bkghist.SetFillColor(plot.CreateTransparentColor(12,0.4))
-bkghist.SetLineColor(0)
-bkghist.SetMarkerSize(0)
+canvas_counter += 1
+c2.SaveAs("{COUNTER}_canvas_with_pads.png".format(COUNTER=str(canvas_counter).zfill(3)))
 
 
-stack.Draw("histsame")
-#Don't draw total bkgs/signal if plotting bkg fractions
-if not fractions and not uniform:
-  bkghist.Draw("e2same")
-  #Add signal, either model dependent or independent
-  if not args.no_signal:
-    if model_dep is True: 
-      sighist.SetLineColor(ROOT.kGreen+3)
-      sighist.SetLineWidth(3)
-      sighist.Draw("histsame")
-    else: 
-      sighist_ggH.SetLineColor(ROOT.kBlue)
-      sighist_bbH.SetLineColor(ROOT.kBlue + 3)
-      sighist_ggH.SetLineWidth(3)
-      sighist_bbH.SetLineWidth(3)
-      sighist_ggH.Draw("histsame")
-      sighist_bbH.Draw("histsame")
-if not soverb_plot and not fractions: blind_datahist.DrawCopy("e0psame")
-axish[0].Draw("axissame")
+hist_indices = [0,2] if y_splitted else [0]
+for i in hist_indices:
+    pads[i].cd()
+    pads[i].GetFrame().SetLineWidth(0)
+    pads[i].SetFrameLineWidth(0)
+    axish[i].Draw("AXIS")
+    canvas_counter += 1
+    c2.SaveAs("{COUNTER}_canvas_with_upper_pads_at_beginning_{}.png".format(str(i),COUNTER=str(canvas_counter).zfill(3)))
+    if i == 0:
+        c2.Print("canvas.root")
 
+    #Draw uncertainty band
+    bkghist.SetFillColor(plot.CreateTransparentColor(12,0.4))
+    bkghist.SetLineColor(0)
+    bkghist.SetMarkerSize(0)
+
+
+    stack.Draw("histsame")
+    canvas_counter += 1
+    c2.SaveAs("{COUNTER}_canvas_with_upper_pads_after_stack_{}.png".format(str(i),COUNTER=str(canvas_counter).zfill(3)))
+    #Don't draw total bkgs/signal if plotting bkg fractions
+    if not fractions and not uniform:
+      bkghist.Draw("e2same")
+      canvas_counter += 1
+      c2.SaveAs("{COUNTER}_canvas_with_upper_pads_after_bkg_uncertainty_{}.png".format(str(i),COUNTER=str(canvas_counter).zfill(3)))
+      #Add signal, either model dependent or independent
+      if not args.no_signal and ((y_splitted and i == 2) or (not y_splitted)):
+        if model_dep is True: 
+          sighist.SetLineColor(ROOT.kGreen+3)
+          sighist.SetLineWidth(3)
+          sighist.Draw("histsame")
+          canvas_counter += 1
+          c2.SaveAs("{COUNTER}_canvas_with_upper_pads_after_signal_{}.png".format(str(i),COUNTER=str(canvas_counter).zfill(3)))
+        else: 
+          sighist_ggH.SetLineColor(ROOT.kBlue)
+          sighist_bbH.SetLineColor(ROOT.kBlue + 3)
+          sighist_ggH.SetLineWidth(3)
+          sighist_bbH.SetLineWidth(3)
+          sighist_ggH.Draw("histsame")
+          sighist_bbH.Draw("histsame")
+    if not soverb_plot and not fractions: blind_datahist.DrawCopy("e0psame")
+    axish[i].Draw("axissame")
+    canvas_counter += 1
+    c2.SaveAs("{COUNTER}_canvas_with_upper_pads_at_the_end_{}.png".format(str(i),COUNTER=str(canvas_counter).zfill(3)))
+
+pads[0].cd()
 #Setup legend
 legend = plot.PositionedLegend(0.30,0.30,3,0.03)
 legend.SetTextFont(42)
@@ -547,6 +626,8 @@ if not fractions:
   if not args.no_signal:
     if model_dep is True: 
         latex.DrawLatex(0.70,0.56,"#splitline{m_{h}^{mod+}, }{m_{A}=%(mA)s GeV, tan#beta=%(tb)s}"%vars())
+        canvas_counter += 1
+        c2.SaveAs("{COUNTER}_canvas_with_upper_pads_after_legend.png".format(COUNTER=str(canvas_counter).zfill(3)))
     else: 
         latex.DrawLatex(0.65,0.56,"#sigma(gg#phi)=%(r_ggH)s pb,"%vars())
         latex.DrawLatex(0.65,0.52,"#sigma(bb#phi)=%(r_bbH)s pb"%vars())
@@ -557,17 +638,24 @@ latex2.SetTextAngle(0)
 latex2.SetTextColor(ROOT.kBlack)
 latex2.SetTextSize(0.028)
 latex2.DrawLatex(0.145,0.955,channel_label)
+canvas_counter += 1
+c2.SaveAs("{COUNTER}_canvas_with_upper_pads_after_channel_title.png".format(COUNTER=str(canvas_counter).zfill(3)))
 
 
 #CMS and lumi labels
 plot.FixTopRange(pads[0], plot.GetPadYMax(pads[0]), extra_pad if extra_pad>0 else 0.30)
 plot.DrawCMSLogo(pads[0], 'CMS', 'Preliminary', 11, 0.045, 0.05, 1.0, '', 1.0)
 plot.DrawTitle(pads[0], args.lumi, 3)
+canvas_counter += 1
+c2.SaveAs("{COUNTER}_canvas_with_upper_pads_after_cms_and_lumi_title.png".format(COUNTER=str(canvas_counter).zfill(3)))
 
 #Add ratio plot if required
 if args.ratio and not soverb_plot and not fractions:
   ratio_bkghist = plot.MakeRatioHist(bkghist,bkghist,True,False)
   blind_datahist = plot.MakeRatioHist(blind_datahist,bkghist,True,False)
+  #sb_hist = bkghist.Clone()
+  #sb_hist.Add(sighist_ggH.Clone())
+  #sb_hist = plot.MakeRatioHist(sb_hist,bkghist,True,False)
   if not frac_ratios:
     pads[1].cd()
     pads[1].SetGrid(0,1)
@@ -576,6 +664,9 @@ if args.ratio and not soverb_plot and not fractions:
     axish[1].SetMaximum(float(args.ratio_range.split(',')[1]))
     ratio_bkghist.SetMarkerSize(0)
     ratio_bkghist.Draw("e2same")
+    #sb_hist.SetMarkerSize(1)
+    #sb_hist.SetMarkerColor(ROOT.kBlue)
+    #sb_hist.Draw("same")
     blind_datahist.DrawCopy("e0same")
     pads[1].RedrawAxis("G")
   else:
@@ -591,6 +682,9 @@ if args.ratio and not soverb_plot and not fractions:
     axish[2].SetMaximum(float(args.ratio_range.split(',')[1]))
     ratio_bkghist.SetMarkerSize(0)
     ratio_bkghist.Draw("e2same")
+    #sb_hist.SetMarkerSize(1)
+    #sb_hist.SetMarkerColor(ROOT.kBlue)
+    #sb_hist.Draw("same")
     blind_datahist.DrawCopy("e0same")
     pads[2].RedrawAxis("G")
     pads[1].RedrawAxis("G")
@@ -609,11 +703,25 @@ if soverb_plot:
     sighist_bbH_forratio.SetLineColor(ROOT.kBlue+3)
     sighist_bbH_forratio.Draw("same")
 
+canvas_counter += 1
+c2.SaveAs("{COUNTER}_canvas_with_upper_pads_after_ratio.png".format(COUNTER=str(canvas_counter).zfill(3)))
+
+print "Pad information"
+for i in [0,2]:
+    print "Pad number",i
+    print "Frame Line Style:",pads[i].GetFrameLineStyle()
+    print "Frame Line Color:",pads[i].GetFrameLineColor()
+    print "Frame Line Width:",pads[i].GetFrameLineWidth()
+    print "Frame Border Size:",pads[i].GetFrameBorderSize()
 
 pads[0].cd()
 pads[0].GetFrame().Draw()
 pads[0].RedrawAxis()
 
+if y_splitted:
+    pads[2].cd()
+    pads[2].GetFrame().Draw()
+    pads[2].RedrawAxis()
 
 #Save as png and pdf with some semi sensible filename
 shape_file_name = shape_file_name.replace(".root","_%(mode)s"%vars())
@@ -624,7 +732,3 @@ if(log_y): outname+="_logy"
 if(log_x): outname+="_logx"
 c2.SaveAs("%(outname)s.png"%vars())
 c2.SaveAs("%(outname)s.pdf"%vars())
-
-
-
-

--- a/MSSMFull2016/scripts/postFitPlotJetFakes.py
+++ b/MSSMFull2016/scripts/postFitPlotJetFakes.py
@@ -563,7 +563,7 @@ pads[0].cd()
 legend = plot.PositionedLegend(0.30,0.30,3,0.03)
 legend.SetTextFont(42)
 legend.SetTextSize(0.025)
-legend.SetFillColor(0)
+legend.SetFillStyle(0)
 if not soverb_plot and not fractions: legend.AddEntry(total_datahist,"Observation","PE")
 #Drawn on legend in reverse order looks better
 bkg_histos.reverse()


### PR DESCRIPTION
Developments on splitted y-scale axis for mt tot plots. Please look over the changes, since it's rather done in a "quick and dirty" approach: y-splitting not supported, if bkg frac ratios is used; only implemented in postFitJetFakes (currently used script). But it should be backward compatible, if you execute the standard plotting.

Cheers,

Artur