### PR TITLE
Impacts: update to support fast, approx. impacts using hesse/robustHesse

### DIFF
--- a/CombineTools/scripts/plotImpacts.py
+++ b/CombineTools/scripts/plotImpacts.py
@@ -25,6 +25,9 @@ parser.add_argument("--pullDef",  default=None, help="Choose the definition of t
 parser.add_argument('--POI', default=None, help='Specify a POI to draw')
 args = parser.parse_args()
 
+if args.transparent:
+    print 'plotImpacts.py: --transparent is now always enabled, the option will be removed in a future update'
+
 externalPullDef = False
 if args.pullDef is not None:
     externalPullDef = True
@@ -267,10 +270,24 @@ for page in xrange(n):
 
     # And back to the second pad to draw the impacts graphs
     pads[1].cd()
-    alpha = 0.7 if args.transparent else 1.0
-    g_impacts_hi.SetFillColor(plot.CreateTransparentColor(46, alpha))
+    alpha = 0.7
+
+    lo_color = {
+        'default': 38,
+        'hesse': ROOT.kOrange - 3,
+        'robust': ROOT.kGreen + 1
+    }
+    hi_color = {
+        'default': 46,
+        'hesse': ROOT.kBlue,
+        'robust': ROOT.kAzure - 5
+    }
+    method = 'default'
+    if 'method' in data and data['method'] in lo_color:
+        method = data['method']
+    g_impacts_hi.SetFillColor(plot.CreateTransparentColor(hi_color[method], alpha))
     g_impacts_hi.Draw('2SAME')
-    g_impacts_lo.SetFillColor(plot.CreateTransparentColor(38, alpha))
+    g_impacts_lo.SetFillColor(plot.CreateTransparentColor(lo_color[method], alpha))
     g_impacts_lo.Draw('2SAME')
     pads[1].RedrawAxis()
 


### PR DESCRIPTION
New approximate (and symmetric) impacts can be calculated by setting `--approx hesse` or `--approx robust` in the `--doFits` and `--output` steps of the impacts workflow. Note the `--doInitialFit` step is not needed in this case. Both methods rely on the calculation of the covariance matrix. The `hesse` option uses the standard HESSE routine in Minuit (i.e. same as used in FitDiagnostics) to calculate the covariance matrix. The `robust` option attempts to make a more accurate estimate of the covariance matrix with regards to approximating the impacts. It is also designed to handle cases with parameters at boundaries and high correlations more reliably. However note that in the case of extremely high correlations it will automatically drop some parameters from the covariance matrix to make it positive-definite. Correspondingly these will be missing from the impacts plot, and may in principle bias the uncertainties on other parameters.

In addition:
 - The behaviour of the `--allPars` option in `combineTool.py -M Impacts` is now always enabled
 - The `--transparent` option in `plotImpacts.py` is now always enabled, to ensure overlaps are visible