### PR TITLE
Refactor SMHTT2017-dev

### DIFF
--- a/HTTSM2017/bin/MorphingSM2017.cpp
+++ b/HTTSM2017/bin/MorphingSM2017.cpp
@@ -104,7 +104,7 @@ int main(int argc, char **argv) {
   } else {
     bkg_procs["et"] = {"W", "ZTT", "QCD", "ZL", "ZJ", "TTT", "TTJ", "VVJ", "VVT"};
     bkg_procs["mt"] = {"W", "ZTT", "QCD", "ZL", "ZJ", "TTT", "TTJ", "VVJ", "VVT"};
-    bkg_procs["tt"] = {"W", "ZTT", "QCD", "ZL", "ZJ", "TTT", "TTJ", "VVJ", "VVT"};
+    bkg_procs["tt"] = {"W", "ZTT", "QCD", "ZL", "ZJ", "TTT", "TTJ"}; // FIXME: Why do we skip VVT and VVJ here?
   }
   bkg_procs["em"] = {"ZTT", "W", "QCD", "ZL", "TT", "VV",  "EWKZ", "ggH_hww125", "qqH_hww125"};
 

--- a/HTTSM2017/interface/HttSystematics_SMRun2.h
+++ b/HTTSM2017/interface/HttSystematics_SMRun2.h
@@ -5,7 +5,7 @@
 namespace ch {
 // Run2 SM analysis systematics
 // Implemented in src/HttSystematics_SMRun2.cc
-void AddSMRun2Systematics(CombineHarvester& cb, int control_region = 0, bool zmm_fit = false, bool ttbar_fit = false);
+void AddSMRun2Systematics(CombineHarvester& cb, bool jetfakes, bool embedding);
 }
 
 #endif

--- a/HTTSM2017/src/HttSystematics_SMRun2.cc
+++ b/HTTSM2017/src/HttSystematics_SMRun2.cc
@@ -1,688 +1,534 @@
 #include "CombineHarvester/HTTSM2017/interface/HttSystematics_SMRun2.h"
-#include <vector>
-#include <string>
-#include "CombineHarvester/CombineTools/interface/Systematics.h"
 #include "CombineHarvester/CombineTools/interface/Process.h"
+#include "CombineHarvester/CombineTools/interface/Systematics.h"
 #include "CombineHarvester/CombineTools/interface/Utilities.h"
+#include <string>
+#include <vector>
 
 using namespace std;
 
 namespace ch {
 
-    using ch::syst::SystMap;
-    using ch::syst::SystMapAsymm;
-    using ch::syst::era;
-    using ch::syst::channel;
-    using ch::syst::bin_id;
-    using ch::syst::process;
-    using ch::syst::bin;
-    using ch::JoinStr;
-
-    void AddSMRun2Systematics(CombineHarvester & cb, int control_region, bool mm_fit, bool ttbar_fit) {
-      std::vector<std::string> sig_procs = {"ggH","qqH","WH_htt","ZH_htt"};
-        // N.B. when adding this list of backgrounds to a nuisance, only
-        // the backgrounds that are included in the background process
-        // defined in MorphingSM2017.cpp are included in the actual DCs
-        // This is a list of all MC based backgrounds
-        // QCD is explicitly excluded
-
-        std::vector<std::string> all_mc_bkgs = {
-            "ZL","ZJ","ZTT","TTJ","TTT","TT",
-            "W","W_rest","ZJ_rest","TTJ_rest","VVJ_rest","VV","VVT","VVJ",
-            "ggH_hww125","qqH_hww125","EWKZ"};
-        std::vector<std::string> all_mc_bkgs_truetau = {
-            "ZTT","TTT","TT","VV","VVT",
-            "ggH_hww125","qqH_hww125","EWKZ"};
-        std::vector<std::string> all_mc_bkgs_no_W = {
-            "ZL","ZJ","ZTT","TTJ","TTT","TT",
-            "ZJ_rest","TTJ_rest","VVJ_rest","VV","VVT","VVJ",
-            "ggH_hww125","qqH_hww125","EWKZ"};
-
-        //##############################################################################
-        //  lumi # FIXME: Lumi is not applied to all backgrounds?
-        //##############################################################################
-
-        cb.cp().process(JoinStr({sig_procs, {"VV","VVT","VVJ","ggH_hww125","qqH_hww125"}})).AddSyst(cb,
-                                            "lumi_13TeV", "lnN", SystMap<>::init(1.025));
-        cb.cp().process({"W_rest", "ZJ_rest", "TTJ_rest", "VVJ_rest"}).channel({"tt"}).AddSyst(cb,"lumi_13TeV", "lnN", SystMap<>::init(1.025));
-
-        //Add luminosity uncertainty for W in em, tt, ttbar and the mm region as norm is from MC // FIXME: This does not make sense anymore.
-        cb.cp().process({"W"}).channel({"tt","em","mm","ttbar"}).AddSyst(cb,
-                                            "lumi_13TeV", "lnN", SystMap<>::init(1.025));
-
-        cb.cp().process({"TTT","TTJ"}).AddSyst(cb,"lumi_13TeV", "lnN", SystMap<>::init(1.025));
-
-        //##############################################################################
-        //  trigger   ##FIXME   the values have been chosen rather arbitrarily # FIXME: What does this mean?
-        //##############################################################################
-
-        cb.cp().process(JoinStr({sig_procs, all_mc_bkgs_no_W})).channel({"mt"}).AddSyst(cb,
-                                             "CMS_eff_trigger_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.02));
-
-        cb.cp().process(JoinStr({sig_procs, all_mc_bkgs_no_W})).channel({"et"}).AddSyst(cb,
-                                             "CMS_eff_trigger_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.02));
-
-        cb.cp().process(JoinStr({sig_procs, all_mc_bkgs})).channel({"em","ttbar"}).AddSyst(cb,
-                                             "CMS_eff_trigger_em_$ERA", "lnN", SystMap<>::init(1.02));
-
-        cb.cp().process(JoinStr({sig_procs, all_mc_bkgs})).channel({"tt"}).AddSyst(cb,
-                                            "CMS_eff_trigger_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.10));
-
-        //##############################################################################
-        //  Electron, muon and tau Id  efficiencies
-        //##############################################################################
-        cb.cp().AddSyst(cb, "CMS_eff_m", "lnN", SystMap<channel, process>::init
-                        ({"mm"}, {"ZTT", "TT", "VV", "ZL", "ZJ"},  1.02)
-                        ({"mt"}, JoinStr({sig_procs, all_mc_bkgs_no_W}),  1.02)
-                        ({"em","ttbar"}, JoinStr({sig_procs, all_mc_bkgs}),  1.02));
-
-        cb.cp().AddSyst(cb, "CMS_eff_e", "lnN", SystMap<channel, process>::init
-                        ({"et"}, JoinStr({sig_procs, all_mc_bkgs_no_W}),  1.02)
-                        ({"em","ttbar"}, JoinStr({sig_procs, all_mc_bkgs}),       1.02));
-
-        // Tau Efficiency applied to all MC
-        // in tautau channel the applied value depends on the number of taus which is determined by
-        // gen match. WJets for example is assumed to have 1 real tau and 1 fake as is TTJ
-        // compared to ZTT which has 2 real taus.
-        // We also have channel specific components and fully correlated components
-
-        // ETau & MuTau
-        cb.cp().process(JoinStr({sig_procs, all_mc_bkgs})).channel({"et","mt"}).AddSyst(cb,
-                                             "CMS_eff_t_$ERA", "lnN", SystMap<>::init(1.045));
-
-        cb.cp().process(JoinStr({sig_procs, all_mc_bkgs})).channel({"et","mt"}).AddSyst(cb,
-                                             "CMS_eff_t_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.02));
-
-        // TauTau - 2 real taus
-        cb.cp().process(JoinStr({sig_procs, {"ZTT","VV","VVT","TTT","EWKZ"}})).channel({"tt"}).AddSyst(cb,
-                                             "CMS_eff_t_$ERA", "lnN", SystMap<>::init(1.09));
-
-        cb.cp().process(JoinStr({sig_procs, {"ZTT","VV","VVT","TTT","EWKZ"}})).channel({"tt"}).AddSyst(cb,
-                                             "CMS_eff_t_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.04));
-
-        // TauTau - 1+ jet to tau fakes
-        cb.cp().process({"TTJ","ZJ","VVJ","W","W_rest","ZJ_rest","TTJ_rest","VVJ_rest"}).channel({"tt"}).AddSyst(cb,
-                                             "CMS_eff_t_$ERA", "lnN", SystMap<>::init(1.06));
-
-        cb.cp().process({"TTJ","ZJ","VVJ","W","W_rest","ZJ_rest","TTJ_rest","VVJ_rest"}).channel({"tt"}).AddSyst(cb,
-                                             "CMS_eff_t_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.02));
-
-        //######################## Tau Id shape uncertainty (added March 08)
-        // FIXME: Do we need these?
-        cb.cp().process({"ZTT"}).channel({"et","mt"}).bin_id({1}).AddSyst(cb,
-                                                            "CMS_tauDMReco_1prong_$ERA", "shape", SystMap<>::init(1.00));
-        cb.cp().process({"ZTT"}).channel({"et","mt"}).bin_id({1}).AddSyst(cb,
-                                                                          "CMS_tauDMReco_1prong1pizero_$ERA", "shape", SystMap<>::init(1.00));
-        cb.cp().process({"ZTT"}).channel({"et","mt"}).bin_id({1}).AddSyst(cb,
-                                                                          "CMS_tauDMReco_3prong_$ERA", "shape", SystMap<>::init(1.00));
-
-        //##############################################################################
-        //  b tag and mistag rate  efficiencies
-        //##############################################################################
-
-        cb.cp().AddSyst(cb, "CMS_htt_eff_b_$ERA", "lnN", SystMap<channel, bin_id, process>::init
-                        ({"em"}, {1}, {"TTJ","TTT","TT"}, 1.035));
-        cb.cp().AddSyst(cb, "CMS_htt_eff_b_$ERA", "lnN", SystMap<channel, bin_id, process>::init
-                        ({"em"}, {2,3}, {"TTJ","TTT","TT"}, 1.05));
-
-        cb.cp().AddSyst(cb, "CMS_htt_eff_b_$ERA", "lnN", SystMap<channel, bin_id, process>::init
-                        ({"em"}, {2, 3}, {"VV","VVT","VVJ"}, 1.015)); // Mainly SingleTop
-
-
-        //##############################################################################
-        //  Electron and tau energy Scale
-        //##############################################################################
-
-        cb.cp().process(JoinStr({sig_procs, all_mc_bkgs, {"QCD"}})).channel({"em"}).AddSyst(cb,
-                                             "CMS_scale_e_$CHANNEL_$ERA", "shape", SystMap<>::init(1.00));
-        // Decay Mode based TES Settings
-        cb.cp().process(JoinStr({sig_procs, all_mc_bkgs_truetau})).channel({"et","mt","tt"}).AddSyst(cb,
-                                                  "CMS_scale_t_1prong_$ERA", "shape", SystMap<>::init(1.00));
-        cb.cp().process(JoinStr({sig_procs, all_mc_bkgs_truetau})).channel({"et","mt","tt"}).AddSyst(cb,
-                                                  "CMS_scale_t_1prong1pizero_$ERA", "shape", SystMap<>::init(1.00));
-        cb.cp().process(JoinStr({sig_procs, all_mc_bkgs_truetau})).channel({"et","mt","tt"}).AddSyst(cb,
-                                                  "CMS_scale_t_3prong_$ERA", "shape", SystMap<>::init(1.00));
-
-        //##############################################################################
-        //  jet and met energy Scale
-        //##############################################################################
-
-        // MET Systematic shapes
-        cb.cp().process(JoinStr({sig_procs, all_mc_bkgs})).channel({"et","mt","tt","em"}).bin_id({1,2,3}).AddSyst(cb,
-                                                  "CMS_scale_met_clustered_$ERA", "shape", SystMap<>::init(1.00));
-        cb.cp().process(JoinStr({sig_procs, all_mc_bkgs})).channel({"et","mt","tt","em"}).bin_id({1,2,3}).AddSyst(cb,
-                                                  "CMS_scale_met_unclustered_$ERA", "shape", SystMap<>::init(1.00));
-
-
-        // Standard JES
-        cb.cp().process(JoinStr({sig_procs, all_mc_bkgs})).channel({"et","mt","tt"}).AddSyst(cb,
-						           "CMS_scale_j_$ERA", "shape", SystMap<>::init(1.00));
-
-        // JES factorization in 27 shapes
-        /*
-        std::vector< std::string > uncertNames = {
-            "AbsoluteFlavMap",
-            "AbsoluteMPFBias",
-            "AbsoluteScale",
-            "AbsoluteStat",
-            //"CorrelationGroupFlavor",
-            //"CorrelationGroupIntercalibration",
-            //"CorrelationGroupMPFInSitu",
-            //"CorrelationGroupUncorrelated",
-            //"CorrelationGroupbJES",
-            //"FlavorPhotonJet",
-            //"FlavorPureBottom",
-            //"FlavorPureCharm",
-            //"FlavorPureGluon",
-            //"FlavorPureQuark",
-            "FlavorQCD",
-            //"FlavorZJet",
-            "Fragmentation",
-            "PileUpDataMC",
-            //"PileUpEnvelope",
-            //"PileUpMuZero",
-            "PileUpPtBB",
-            "PileUpPtEC1",
-            "PileUpPtEC2",
-            "PileUpPtHF",
-            "PileUpPtRef",
-            "RelativeBal",
-            "RelativeFSR",
-            "RelativeJEREC1",
-            "RelativeJEREC2",
-            "RelativeJERHF",
-            "RelativePtBB",
-            "RelativePtEC1",
-            "RelativePtEC2",
-            "RelativePtHF",
-            "RelativeStatEC",
-            "RelativeStatFSR",
-            "RelativeStatHF",
-            "SinglePionECAL",
-            "SinglePionHCAL",
-            //"SubTotalAbsolute",
-            //"SubTotalMC",
-            //"SubTotalPileUp",
-            //"SubTotalPt",
-            //"SubTotalRelative",
-            //"SubTotalScale",
-            "TimePtEta",
-            //"TimeRunBCD",
-            //"TimeRunE",
-            //"TimeRunF",
-            //"TimeRunGH",
-            //"TotalNoFlavorNoTime",
-            //"TotalNoFlavor",
-            //"TotalNoTime",
-            //"Total", // Total JES value, don't include
-            //"Closure", // Closure Measure, don't include
-        }; // end uncertNames
-
-        for (string uncert:uncertNames){
-         cb.cp().process(JoinStr({sig_procs, all_mc_bkgs})).channel({"tt","mt", "et"}).AddSyst(cb,
-         "CMS_scale_j_"+uncert+"_$ERA", "shape", SystMap<>::init(1.00));
-         }
-         */
-
-        //##############################################################################
-        //  Background normalization uncertainties
-        //##############################################################################
-
-        //   Diboson  Normalisation - fully correlated
-        cb.cp().process({"VV","VVT","VVJ","VVJ_rest"}).AddSyst(cb,
-                                        "CMS_htt_vvXsec_13TeV", "lnN", SystMap<>::init(1.05));
-        //   ttbar Normalisation - fully correlated
-	    cb.cp().process({"TT","TTT","TTJ","TTJ_rest"}).AddSyst(cb,
-					  "CMS_htt_tjXsec_13TeV", "lnN", SystMap<>::init(1.06));
-
-        // W norm, just for em, tt and the mm region where MC norm is from MC // FIXME: This needs to be done everywhere.
-        cb.cp().process({"W"}).channel({"em"}).AddSyst(cb,
-                                                       "CMS_htt_jetFakeLep_13TeV", "lnN", SystMap<>::init(1.20));
-
-        cb.cp().process({"W"}).channel({"tt"}).AddSyst(cb,
-                                                       "CMS_htt_wjXsec_13TeV", "lnN", SystMap<>::init(1.04));
-
-
-        // QCD norm, just for em  decorrelating QCD BG for differenet categories
-
-        // QCD norm, just for tt // FIXME: Does not fit for our analysis.
-        cb.cp().process({"QCD"}).channel({"em"}).bin_id({1}).AddSyst(cb,
-                                             "CMS_htt_QCD_0jet_$CHANNEL_13TeV", "lnN", SystMap<>::init(1.10));
-        cb.cp().process({"QCD"}).channel({"em"}).bin_id({2}).AddSyst(cb,
-                                             "CMS_htt_QCD_boosted_$CHANNEL_13TeV", "lnN", SystMap<>::init(1.10));
-        cb.cp().process({"QCD"}).channel({"em"}).bin_id({3}).AddSyst(cb,
-                                             "CMS_htt_QCD_VBF_$CHANNEL_13TeV", "lnN", SystMap<>::init(1.20));
-
-
-        // QCD norm, just for tt // FIXME: Does not fit for our analysis.
-        cb.cp().process({"QCD"}).channel({"tt"}).bin_id({1}).AddSyst(cb,
-                                             "CMS_htt_QCD_0jet_$CHANNEL_13TeV", "lnN", SystMap<>::init(1.027));
-        cb.cp().process({"QCD"}).channel({"tt"}).bin_id({2}).AddSyst(cb,
-                                             "CMS_htt_QCD_boosted_$CHANNEL_13TeV", "lnN", SystMap<>::init(1.027));
-        cb.cp().process({"QCD"}).channel({"tt"}).bin_id({3}).AddSyst(cb,
-                                             "CMS_htt_QCD_VBF_$CHANNEL_13TeV", "lnN", SystMap<>::init(1.15));
-
-
-        // Iso to antiiso extrapolation
-        cb.cp().process({"QCD"}).channel({"mt"}).bin_id({1,2,3}).AddSyst(cb,
-                                             "QCD_Extrap_Iso_nonIso_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.20));
-        cb.cp().process({"QCD"}).channel({"et"}).bin_id({1,2,3}).AddSyst(cb,
-                                             "QCD_Extrap_Iso_nonIso_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.20));
-
-
-        //This should affect only shape (normalized to nominal values)
-	/* MISSING SO FAR # FIXME: What does this mean?
-        cb.cp().process({"QCD"}).channel({"et","mt"}).bin_id({1}).AddSyst(cb,
-                                             "WSFUncert_$CHANNEL_0jet_$ERA", "shape", SystMap<>::init(1.00));
-        cb.cp().process({"QCD"}).channel({"et","mt"}).bin_id({2}).AddSyst(cb,
-                                             "WSFUncert_$CHANNEL_boosted_$ERA", "shape", SystMap<>::init(1.00));
-        cb.cp().process({"QCD"}).channel({"et","mt"}).bin_id({3}).AddSyst(cb,
-                                             "WSFUncert_$CHANNEL_vbf_$ERA", "shape", SystMap<>::init(1.00));
-	*/
-
-
-        // based on the Ersatz study in Run1 // FIXME: This is still correct?
-        cb.cp().process({"W"}).channel({"et","mt"}).bin_id({1}).AddSyst(cb,
-                                             "WHighMTtoLowMT_0jet_$ERA", "lnN", SystMap<>::init(1.10));
-        cb.cp().process({"W"}).channel({"et","mt"}).bin_id({2}).AddSyst(cb,
-                                             "WHighMTtoLowMT_boosted_$ERA", "lnN", SystMap<>::init(1.05));
-        cb.cp().process({"W"}).channel({"et","mt"}).bin_id({3}).AddSyst(cb,
-                                             "WHighMTtoLowMT_vbf_$ERA", "lnN", SystMap<>::init(1.10));
-
-        //##############################################################################
-        //  DY LO->NLO reweighting, Between no and twice the correction.
-        //##############################################################################
-
-        cb.cp().process( {"ZTT","ZJ","ZL","ZJ_rest"}).channel({"et","mt","tt"}).AddSyst(cb,
-                                             "CMS_htt_dyShape_$ERA", "shape", SystMap<>::init(1.00));
-        cb.cp().process( {"ZTT","ZL"}).channel({"em"}).AddSyst(cb,
-                                             "CMS_htt_dyShape_$ERA", "shape", SystMap<>::init(1.00));
-
-
-        //##############################################################################
-        // Ttbar shape reweighting, Between no and twice the correction
-        //##############################################################################
-
-        cb.cp().process( {"TTJ","TTT","TTJ_rest"}).channel({"tt"}).AddSyst(cb,
-                                        "CMS_htt_ttbarShape_$ERA", "shape", SystMap<>::init(1.00));
-        cb.cp().process( {"TTJ","TTT"}).channel({"et","mt"}).AddSyst(cb,
-                                        "CMS_htt_ttbarShape_$ERA", "shape", SystMap<>::init(1.00));
-        cb.cp().process( {"TT"}).channel({"em"}).AddSyst(cb,
-                                        "CMS_htt_ttbarShape_$ERA", "shape", SystMap<>::init(1.00));
-
-        //##############################################################################
-        // ZL shape  and electron/muon  to tau fake only in  mt and et channels
-        //##############################################################################
-
-        cb.cp().process( {"ZL"}).channel({"mt","et"}).AddSyst(cb,
-                                                         "CMS_ZLShape_$CHANNEL_1prong_$ERA", "shape", SystMap<>::init(1.00));
-        cb.cp().process( {"ZL"}).channel({"mt","et"}).AddSyst(cb,
-                                                         "CMS_ZLShape_$CHANNEL_1prong1pizero_$ERA", "shape", SystMap<>::init(1.00));
-
-
-        cb.cp().process( {"ZL"}).channel({"mt"}).bin_id({1,2,3}).AddSyst(cb,
-                                                                     "CMS_mFakeTau_1prong_$ERA", "shape", SystMap<>::init(1.00));
-        cb.cp().process( {"ZL"}).channel({"mt"}).bin_id({1,2,3}).AddSyst(cb,
-                                                                     "CMS_mFakeTau_1prong1pizero_$ERA", "shape", SystMap<>::init(1.00));
-        cb.cp().process( {"ZL"}).channel({"et"}).bin_id({1,2,3}).AddSyst(cb,
-                                                                     "CMS_eFakeTau_1prong_$ERA", "shape", SystMap<>::init(1.00));
-        cb.cp().process( {"ZL"}).channel({"et"}).bin_id({1,2,3}).AddSyst(cb,
-                                                                     "CMS_eFakeTau_1prong1pizero_$ERA", "shape", SystMap<>::init(1.00));
-
-        //##############################################################################
-        // jet  to tau fake only in tt, mt and et channels
-        //##############################################################################
-
-        cb.cp().process( {"TTJ","ZJ","VVJ","W_rest","ZJ_rest","TTJ_rest","VVJ_rest"}).channel({"tt","mt","et"}).AddSyst(cb,
-                                                                            "CMS_htt_jetToTauFake_$ERA", "shape", SystMap<>::init(1.00));
-
-        // FIXME: This does not make sense anymore?
-        cb.cp().process( {"W"}).channel({"tt","mt","et"}).bin_id({1,2,3,13,14,15}).AddSyst(cb,
-                                                                "CMS_htt_jetToTauFake_$ERA", "shape", SystMap<>::init(1.00));
-
-        //##############################################################################
-        // Theoretical Uncertainties on signal
-        //##############################################################################
-
-        //scale_gg on signal // FIXME: We don't have this. Should we use the log-normal uncertainties below?
-        cb.cp().process( {"ggH"}).channel({"et","mt","tt","em"}).AddSyst(cb,
-                                             "CMS_scale_gg_$ERA", "shape", SystMap<>::init(1.00));
-
-        // Scale uncertainty on signal Applies to ggH in boosted and VBF. Event-by-event weight applied as a func(on of pth or mjj. Fully correlated between categories and final states.
-
-        // Covered by CMS_scale_gg above
-        //cb.cp().AddSyst(cb, "CMS_ggH_QCDUnc", "lnN", SystMap<channel, bin_id, process>::init
-        //                ({"em"},{1},{"ggH"}, 0.93)
-        //                ({"et"},{1},{"ggH"}, 0.93)
-        //                ({"mt"},{1},{"ggH"}, 0.93)
-        //                ({"tt"},{1},{"ggH"}, 0.93)
-        //
-        //                ({"em"},{2},{"ggH"}, 1.15)
-        //                ({"et"},{2},{"ggH"}, 1.18)
-        //                ({"mt"},{2},{"ggH"}, 1.18)
-        //                ({"tt"},{2},{"ggH"}, 1.20)
-        //
-        //
-        //                ({"em"},{3},{"ggH"}, 1.25)
-        //                ({"et"},{3},{"ggH"}, 1.15)
-        //                ({"mt"},{3},{"ggH"}, 1.08)
-        //                ({"tt"},{3},{"ggH"}, 1.10)
-        //                );
-
-            cb.cp().AddSyst(cb, "CMS_qqH_QCDUnc", "lnN", SystMap<channel, bin_id, process>::init
-                        ({"em"},{1},{"qqH"}, 0.997)
-                        ({"et"},{1},{"qqH"}, 1.003)
-                        ({"mt"},{1},{"qqH"}, 0.998)
-                        ({"tt"},{1},{"qqH"}, 0.997)
-
-                        ({"em"},{2},{"qqH"}, 1.004)
-                        ({"et"},{2},{"qqH"}, 1.004)
-                        ({"mt"},{2},{"qqH"}, 1.002)
-                        ({"tt"},{2},{"qqH"}, 1.003)
-
-
-                        ({"em"},{3},{"qqH"}, 1.005)
-                        ({"et"},{3},{"qqH"}, 1.005)
-                        ({"mt"},{3},{"qqH"}, 1.002)
-                        ({"tt"},{3},{"qqH"}, 1.003)
-                        );
-
-        cb.cp().AddSyst(cb, "CMS_ggH_PDF", "lnN", SystMap<channel, bin_id, process>::init
-                        ({"em"},{1},{"ggH"}, 1.007)
-                        ({"et"},{1},{"ggH"}, 1.007)
-                        ({"mt"},{1},{"ggH"}, 1.007)
-                        ({"tt"},{1},{"ggH"}, 1.009)
-
-                        ({"em"},{2},{"ggH"}, 1.007)
-                        ({"et"},{2},{"ggH"}, 1.007)
-                        ({"mt"},{2},{"ggH"}, 1.007)
-                        ({"tt"},{2},{"ggH"}, 1.009)
-
-
-                        ({"em"},{3},{"ggH"}, 1.007)
-                        ({"et"},{3},{"ggH"}, 1.007)
-                        ({"mt"},{3},{"ggH"}, 1.007)
-                        ({"tt"},{3},{"ggH"}, 1.009)
-                        );
-
-        cb.cp().AddSyst(cb, "CMS_qqH_PDF", "lnN", SystMap<channel, bin_id, process>::init
-                        ({"em"},{1},{"qqH"}, 1.011)
-                        ({"et"},{1},{"qqH"}, 1.005)
-                        ({"mt"},{1},{"qqH"}, 1.005)
-                        ({"tt"},{1},{"qqH"}, 1.008)
-
-                        ({"em"},{2},{"qqH"}, 1.005)
-                        ({"et"},{2},{"qqH"}, 1.002)
-                        ({"mt"},{2},{"qqH"}, 1.002)
-                        ({"tt"},{2},{"qqH"}, 1.003)
-
-
-                        ({"em"},{3},{"qqH"}, 1.005)
-                        ({"et"},{3},{"qqH"}, 1.005)
-                        ({"mt"},{3},{"qqH"}, 1.005)
-                        ({"tt"},{3},{"qqH"}, 1.005)
-                        );
-
-        cb.cp().AddSyst(cb, "CMS_ggH_UEPS", "lnN", SystMap<channel, bin_id, process>::init
-                        ({"em"},{1},{"ggH"}, 1.015)
-                        ({"et"},{1},{"ggH"}, 1.015)
-                        ({"mt"},{1},{"ggH"}, 1.015)
-                        ({"tt"},{1},{"ggH"}, 1.015)
-
-                        ({"em"},{2},{"ggH"}, 0.945)
-                        ({"et"},{2},{"ggH"}, 0.945)
-                        ({"mt"},{2},{"ggH"}, 0.945)
-                        ({"tt"},{2},{"ggH"}, 0.945)
-
-                        ({"em"},{3},{"ggH"}, 1.03)
-                        ({"et"},{3},{"ggH"}, 1.03)
-                        ({"mt"},{3},{"ggH"}, 1.03)
-                        ({"tt"},{3},{"ggH"}, 1.03)
-                        );
-
-        cb.cp().AddSyst(cb, "CMS_qqH_UEPS", "lnN", SystMap<channel, bin_id, process>::init
-                        ({"em"},{1},{"qqH"}, 1.015)
-                        ({"et"},{1},{"qqH"}, 1.015)
-                        ({"mt"},{1},{"qqH"}, 1.015)
-                        ({"tt"},{1},{"qqH"}, 1.015)
-
-                        ({"em"},{2},{"qqH"}, 0.945)
-                        ({"et"},{2},{"qqH"}, 0.945)
-                        ({"mt"},{2},{"qqH"}, 0.945)
-                        ({"tt"},{2},{"qqH"}, 0.945)
-
-                        ({"em"},{3},{"qqH"}, 1.03)
-                        ({"et"},{3},{"qqH"}, 1.03)
-                        ({"mt"},{3},{"qqH"}, 1.03)
-                        ({"tt"},{3},{"qqH"}, 1.03)
-                        );
-
-
-        /* // FIXME: What is that?
-        cb.cp().AddSyst(cb, "CMS_ggH_mcComp", "lnN", SystMap<channel, bin_id, process>::init
-                        ({"em"},{1},{"ggH"}, 0.95)
-                        ({"et"},{1},{"ggH"}, 0.95)
-                        ({"mt"},{1},{"ggH"}, 0.95)
-                        ({"tt"},{1},{"ggH"}, 0.95)
-
-                        ({"em"},{2},{"ggH"}, 1.15)
-                        ({"et"},{2},{"ggH"}, 1.15)
-                        ({"mt"},{2},{"ggH"}, 1.15)
-                        ({"tt"},{2},{"ggH"}, 1.15)
-
-                        ({"em"},{3},{"ggH"}, 1.20)
-                        ({"et"},{3},{"ggH"}, 1.10)
-                        ({"mt"},{3},{"ggH"}, 1.10)
-                        ({"tt"},{3},{"ggH"}, 1.10)
-                        );
-
-
-
-        cb.cp().AddSyst(cb, "CMS_qqH_mcComp", "lnN", SystMap<channel, bin_id, process>::init
-                        ({"em"},{1},{"qqH"}, 0.95)
-                        ({"et"},{1},{"qqH"}, 0.95)
-                        ({"mt"},{1},{"qqH"}, 1.05)
-                        ({"tt"},{1},{"qqH"}, 1.05)
-
-                        ({"em"},{2},{"qqH"}, 1.10)
-                        ({"et"},{2},{"qqH"}, 1.10)
-                        ({"mt"},{2},{"qqH"}, 1.10)
-                        ({"tt"},{2},{"qqH"}, 1.05)
-
-                        ({"em"},{3},{"qqH"}, 0.90)
-                        ({"et"},{3},{"qqH"}, 0.90)
-                        ({"mt"},{3},{"qqH"}, 0.90)
-                        ({"tt"},{3},{"qqH"}, 0.90)
-                        );
-        */
-
-        //    Uncertainty on BR for HTT @ 125 GeV
-        cb.cp().process(sig_procs).AddSyst(cb,"BR_htt_THU", "lnN", SystMap<>::init(1.017));
-        cb.cp().process(sig_procs).AddSyst(cb,"BR_htt_PU_mq", "lnN", SystMap<>::init(1.0099));
-        cb.cp().process(sig_procs).AddSyst(cb,"BR_htt_PU_alphas", "lnN", SystMap<>::init(1.0062));
-
-        //    Uncertainty on BR of HWW @ 125 GeV
-        cb.cp().process({"ggH_hww125","qqH_hww125"}).AddSyst(cb,"BR_hww_THU", "lnN", SystMap<>::init(1.0099));
-        cb.cp().process({"ggH_hww125","qqH_hww125"}).AddSyst(cb,"BR_hww_PU_mq", "lnN", SystMap<>::init(1.0099));
-        cb.cp().process({"ggH_hww125","qqH_hww125"}).AddSyst(cb,"BR_hww_PU_alphas", "lnN", SystMap<>::init(1.0066));
-
-
-        cb.cp().process({"ggH","ggH_hww125"}).AddSyst(cb,"QCDScale_ggH", "lnN", SystMap<>::init(1.039));
-        cb.cp().process({"qqH","qqH_hww125"}).AddSyst(cb,"QCDScale_qqH", "lnN", SystMap<>::init(1.004));
-        cb.cp().process({"WH_htt"}).AddSyst(cb,"QCDScale_VH", "lnN", SystMap<>::init(1.007));
-        cb.cp().process({"ZH_htt"}).AddSyst(cb,"QCDScale_VH", "lnN", SystMap<>::init(1.038));
-
-        cb.cp().process({"ggH","ggH_hww125"}).AddSyst(cb,"pdf_Higgs_gg", "lnN", SystMap<>::init(1.032));
-        cb.cp().process({"qqH","qqH_hww125"}).AddSyst(cb,"pdf_Higgs_qq", "lnN", SystMap<>::init(1.021));
-        cb.cp().process({"WH_htt"}).AddSyst(cb,"pdf_Higgs_VH", "lnN", SystMap<>::init(1.019));
-        cb.cp().process({"ZH_htt"}).AddSyst(cb,"pdf_Higgs_VH", "lnN", SystMap<>::init(1.016));
-
-        //   Additonal uncertainties applied to the paper i.e. top mass // FIXME: What is this doing?
-        cb.cp().process( {"ggH"}).channel({"et","mt","em","tt"}).AddSyst(cb,
-                                                                         "TopMassTreatment_$ERA", "shape", SystMap<>::init(1.00));
-
-        // FIXME: What does the *_STXSmig* uncertainties do?
-        cb.cp().AddSyst(cb, "CMS_ggH_STXSmig01", "lnN", SystMap<channel, bin_id, process>::init
-                        ({"em"},{1},{"ggH"}, 0.959)
-                        ({"et"},{1},{"ggH"}, 0.959)
-                        ({"mt"},{1},{"ggH"}, 0.959)
-                        ({"tt"},{1},{"ggH"}, 0.959)
-
-                        ({"em"},{2},{"ggH"}, 1.079)
-                        ({"et"},{2},{"ggH"}, 1.079)
-                        ({"mt"},{2},{"ggH"}, 1.079)
-                        ({"tt"},{2},{"ggH"}, 1.079)
-
-                        ({"em"},{3},{"ggH"}, 1.039)
-                        ({"et"},{3},{"ggH"}, 1.039)
-                        ({"mt"},{3},{"ggH"}, 1.039)
-                        ({"tt"},{3},{"ggH"}, 1.039)
-                        );
-
-        cb.cp().AddSyst(cb, "CMS_ggH_STXSmig12", "lnN", SystMap<channel, bin_id, process>::init
-                        ({"em"},{1},{"ggH"}, 1.000)
-                        ({"et"},{1},{"ggH"}, 1.000)
-                        ({"mt"},{1},{"ggH"}, 1.000)
-                        ({"tt"},{1},{"ggH"}, 1.000)
-
-                        ({"em"},{2},{"ggH"}, 0.932)
-                        ({"et"},{2},{"ggH"}, 0.932)
-                        ({"mt"},{2},{"ggH"}, 0.932)
-                        ({"tt"},{2},{"ggH"}, 0.932)
-
-                        ({"em"},{3},{"ggH"}, 1.161)
-                        ({"et"},{3},{"ggH"}, 1.161)
-                        ({"mt"},{3},{"ggH"}, 1.161)
-                        ({"tt"},{3},{"ggH"}, 1.161)
-                        );
-
-        cb.cp().AddSyst(cb, "CMS_ggH_STXSVBF2j", "lnN", SystMap<channel, bin_id, process>::init
-                        ({"em"},{1},{"ggH"}, 1.000)
-                        ({"et"},{1},{"ggH"}, 1.000)
-                        ({"mt"},{1},{"ggH"}, 1.000)
-                        ({"tt"},{1},{"ggH"}, 1.000)
-
-                        ({"em"},{2},{"ggH"}, 1.000)
-                        ({"et"},{2},{"ggH"}, 1.000)
-                        ({"mt"},{2},{"ggH"}, 1.000)
-                        ({"tt"},{2},{"ggH"}, 1.000)
-
-                        ({"em"},{3},{"ggH"}, 1.200)
-                        ({"et"},{3},{"ggH"}, 1.200)
-                        ({"mt"},{3},{"ggH"}, 1.200)
-                        ({"tt"},{3},{"ggH"}, 1.200)
-                        );
-
-        //  // Recoil corrections // FIXME: Why this is not used?
-        //  // ------------------
-        //  // These should not be applied to the W in all control regions becasuse we should
-        //  // treat it as an uncertainty on the low/high mT factor.
-        //  // For now we also avoid applying this to any of the high-mT control regions
-        //  // as the exact (anti-)correlation with low mT needs to be established
-        //  // CHECK THIS
-        //  cb.cp().AddSyst(cb,
-        //    "CMS_htt_boson_scale_met_$ERA", "lnN", SystMap<channel, bin_id, process>::init
-        //    ({"et", "mt", "em", "tt"}, {1, 2, 3, 4,5,6}, JoinStr({signal, {"ZTT", "W"}}), 1.02));
-        //
-
-            // Z->mumu CR normalization propagation // FIXME: This does not make sense anymore
-            // 0jet normalization only
-            cb.cp().process({"ZTT", "ZL", "ZJ", "ZJ_rest", "EWKZ"}).AddSyst(cb,
-                                             "CMS_htt_zmm_norm_extrap_0jet_$CHANNEL_$ERA", "lnN",
-                                             SystMap<channel, bin_id>::init({"em","tt"},{1}, 1.07));
-            cb.cp().process({"ZTT", "ZL", "ZJ", "ZJ_rest", "EWKZ"}).AddSyst(cb,
-                                             "CMS_htt_zmm_norm_extrap_0jet_lt_$ERA", "lnN",
-                                             SystMap<channel, bin_id>::init({"et","mt"},{1}, 1.07));
-
-            // boosted normalization only
-            cb.cp().process({"ZTT", "ZL", "ZJ", "ZJ_rest", "EWKZ"}).AddSyst(cb,
-                                             "CMS_htt_zmm_norm_extrap_boosted_$CHANNEL_$ERA", "lnN",
-                                             SystMap<channel, bin_id>::init({"em","tt"},{2}, 1.07));
-            cb.cp().process({"ZTT", "ZL", "ZJ", "ZJ_rest", "EWKZ"}).AddSyst(cb,
-                                             "CMS_htt_zmm_norm_extrap_boosted_lt_$ERA", "lnN",
-                                             SystMap<channel, bin_id>::init({"et","mt"},{2}, 1.07));
-
-            // VBF norm and shape for et/mt/tt
-            cb.cp().process( {"ZL","ZTT","ZJ", "ZJ_rest", "EWKZ"}).channel({"em"}).bin_id({3}).AddSyst(cb,
-                                             "CMS_htt_zmm_norm_extrap_VBF_em_$ERA", "lnN", SystMap<>::init(1.15));
-            cb.cp().process( {"ZL","ZTT","ZJ", "ZJ_rest", "EWKZ"}).channel({"et","mt"}).bin_id({3}).AddSyst(cb,
-                                             "CMS_htt_zmm_norm_extrap_VBF_lt_$ERA", "lnN", SystMap<>::init(1.15));
-            cb.cp().process( {"ZL","ZTT","ZJ", "ZJ_rest", "EWKZ"}).channel({"tt"}).bin_id({3}).AddSyst(cb,
-                                             "CMS_htt_zmm_norm_extrap_VBF_tt_$ERA", "lnN", SystMap<>::init(1.10));
-
-//            // FIXME should have EWKZ in all // FIXME: This is important for us?
-//            cb.cp().process( {"ZL","ZTT","ZJ", "ZJ_rest", "EWKZ"}).channel({"tt"}).bin_id({3}).AddSyst(cb,
-//                                             "CMS_htt_zmumuShape_VBF_$ERA", "shape", SystMap<>::init(1.00));
-//            cb.cp().process( {"ZL","ZTT","ZJ", "ZJ_rest", "EWKZ"}).channel({"mt","et"}).bin_id({3}).AddSyst(cb,
-//                                             "CMS_htt_zmumuShape_VBF_$ERA", "shape", SystMap<>::init(1.00));
-//            cb.cp().process( {"ZL","ZTT","ZJ", "ZJ_rest"}).channel({"em"}).bin_id({3}).AddSyst(cb,
-//                                            "CMS_htt_zmumuShape_VBF_$ERA", "shape", SystMap<>::init(1.00));
-
-            cb.cp().process( {"ZL","ZTT","ZJ", "ZJ_rest", "EWKZ"}).channel({"tt","et","mt"}).bin_id({3}).AddSyst(cb,
-                                            "CMS_htt_zmumuShape_VBF_$ERA", "shape", SystMap<>::init(1.00));
-            cb.cp().process( {"ZL","ZTT","ZJ", "ZJ_rest"}).channel({"em"}).bin_id({3}).AddSyst(cb,
-                                            "CMS_htt_zmumuShape_VBF_$ERA", "shape", SystMap<>::init(1.00));
-
-	//jet fakes: shape uncertainties
-        cb.cp().process({"jetFakes"}).channel({"mt","et","tt"}).AddSyst(cb, "CMS_htt_norm_ff_qcd_1prong_njet0_$CHANNEL_stat_13TeV", "shape", SystMap<>::init(1.00));
-        cb.cp().process({"jetFakes"}).channel({"mt","et","tt"}).AddSyst(cb, "CMS_htt_norm_ff_qcd_1prong_njet1_$CHANNEL_stat_13TeV", "shape", SystMap<>::init(1.00));
-        cb.cp().process({"jetFakes"}).channel({"mt","et","tt"}).AddSyst(cb, "CMS_htt_norm_ff_qcd_3prong_njet0_$CHANNEL_stat_13TeV", "shape", SystMap<>::init(1.00));
-        cb.cp().process({"jetFakes"}).channel({"mt","et","tt"}).AddSyst(cb, "CMS_htt_norm_ff_qcd_3prong_njet1_$CHANNEL_stat_13TeV", "shape", SystMap<>::init(1.00));
-
-        cb.cp().process({"jetFakes"}).channel({"mt","et"}).AddSyst(cb, "CMS_htt_norm_ff_w_1prong_njet0_$CHANNEL_stat_13TeV", "shape", SystMap<>::init(1.00));
-        cb.cp().process({"jetFakes"}).channel({"mt","et"}).AddSyst(cb, "CMS_htt_norm_ff_w_1prong_njet1_$CHANNEL_stat_13TeV", "shape", SystMap<>::init(1.00));
-        cb.cp().process({"jetFakes"}).channel({"mt","et"}).AddSyst(cb, "CMS_htt_norm_ff_w_3prong_njet0_$CHANNEL_stat_13TeV", "shape", SystMap<>::init(1.00));
-        cb.cp().process({"jetFakes"}).channel({"mt","et"}).AddSyst(cb, "CMS_htt_norm_ff_w_3prong_njet1_$CHANNEL_stat_13TeV", "shape", SystMap<>::init(1.00));
-
-        cb.cp().process({"jetFakes"}).channel({"mt","et"}).AddSyst(cb, "CMS_htt_norm_ff_tt_1prong_njet0_stat_13TeV", "shape", SystMap<>::init(1.00));
-        cb.cp().process({"jetFakes"}).channel({"mt","et"}).AddSyst(cb, "CMS_htt_norm_ff_tt_1prong_njet1_stat_13TeV", "shape", SystMap<>::init(1.00));
-        cb.cp().process({"jetFakes"}).channel({"mt","et"}).AddSyst(cb, "CMS_htt_norm_ff_tt_3prong_njet0_stat_13TeV", "shape", SystMap<>::init(1.00));
-        cb.cp().process({"jetFakes"}).channel({"mt","et"}).AddSyst(cb, "CMS_htt_norm_ff_tt_3prong_njet1_stat_13TeV", "shape", SystMap<>::init(1.00));
-
-        cb.cp().process({"jetFakes"}).channel({"mt","et","tt"}).AddSyst(cb, "CMS_htt_norm_ff_qcd_$CHANNEL_syst_13TeV", "shape", SystMap<>::init(1.00));
-
-        cb.cp().process({"jetFakes"}).channel({"mt","et"}).AddSyst(cb, "CMS_htt_norm_ff_w_syst_13TeV", "shape", SystMap<>::init(1.00));
-        cb.cp().process({"jetFakes"}).channel({"mt","et"}).AddSyst(cb, "CMS_htt_norm_ff_tt_syst_13TeV", "shape", SystMap<>::init(1.00));
-
-        cb.cp().process({"jetFakes"}).channel({"tt"}).AddSyst(cb, "CMS_htt_norm_ff_w_$CHANNEL_syst_13TeV", "shape", SystMap<>::init(1.00));
-        cb.cp().process({"jetFakes"}).channel({"tt"}).AddSyst(cb, "CMS_htt_norm_ff_ttbar_$CHANNEL_syst_13TeV", "shape", SystMap<>::init(1.00));
-
-        //jet fakes: stat norm unc
-	cb.cp().process({"jetFakes"}).channel({"mt","et","tt"}).AddSyst(cb, "CMS_htt_ff_norm_stat_$CHANNEL_$BIN_13TeV", "lnN", SystMap<channel, bin_id>::init
-                                                                        ({"mt"}, {1}, 1.04)
-                                                                        ({"mt"}, {2}, 1.03)
-                                                                        ({"mt"}, {3}, 1.045)
-                                                                        ({"et"}, {1}, 1.04)
-                                                                        ({"et"}, {2}, 1.05)
-                                                                        ({"et"}, {3}, 1.065)
-                                                                        ({"tt"}, {1}, 1.03)
-                                                                        ({"tt"}, {2}, 1.04)
-                                                                        ({"tt"}, {3}, 1.05)
-                                                                        );
-        //jet fakes: syst norm: bin-correlated
-        cb.cp().process({"jetFakes"}).channel({"mt","et","tt"}).AddSyst(cb, "CMS_htt_ff_norm_syst_$CHANNEL_13TeV", "lnN", SystMap<channel, bin_id>::init
-                                                                        ({"mt"}, {1}, 1.065)
-                                                                        ({"mt"}, {2}, 1.062)
-                                                                        ({"mt"}, {3}, 1.078)
-                                                                        ({"et"}, {1}, 1.073)
-                                                                        ({"et"}, {2}, 1.067)
-                                                                        ({"et"}, {3}, 1.083)
-                                                                        ({"tt"}, {1}, 1.026)
-                                                                        ({"tt"}, {2}, 1.032)
-                                                                        ({"tt"}, {3}, 1.040)
-                                                                        );
-        //jet fakes: syst norm: bin-dependent
-        cb.cp().process({"jetFakes"}).channel({"mt","et","tt"}).AddSyst(cb, "CMS_htt_ff_sub_syst_$CHANNEL_$BIN_13TeV", "lnN", SystMap<channel, bin_id>::init
-                                                                        ({"mt"}, {1}, 1.06)
-                                                                        ({"mt"}, {2}, 1.04)
-                                                                        ({"mt"}, {3}, 1.04)
-                                                                        ({"et"}, {1}, 1.06)
-                                                                        ({"et"}, {2}, 1.04)
-                                                                        ({"et"}, {3}, 1.04)
-                                                                        ({"tt"}, {1}, 1.06)
-                                                                        ({"tt"}, {2}, 1.04)
-									);
-
-
-    }
+using ch::syst::SystMap;
+using ch::syst::SystMapAsymm;
+using ch::syst::era;
+using ch::syst::channel;
+using ch::syst::bin_id;
+using ch::syst::process;
+using ch::syst::bin;
+using ch::JoinStr;
+
+void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding) {
+  // Error-handling
+  if (embedding)
+    throw std::runtime_error("Embedding is not yet implemented.");
+
+  // ##########################################################################
+  // Define groups of processes
+  // ##########################################################################
+
+  // Signal processes
+  std::vector<std::string> signals_ggH = {
+      // STXS stage 0
+      "ggH",
+      // STXS stage 1
+      "ggH_0J", "ggH_1J", "ggH_GE2J", "ggH_VBFTOPO"};
+  std::vector<std::string> signals_qqH = {
+      // STXS stage 0
+      "qqH"
+      // STXS stage 1
+      "qqH_VBFTOPO_JET3", "qqH_VBFTOPO_JET3VETO", "qqH_REST", "qqH_PTJET1_GT200"};
+  std::vector<std::string> signals_VH = {
+      // STXS stage 0
+      "WH_htt", "ZH_htt"};
+  std::vector<std::string> signals = JoinStr({signals_ggH, signals_qqH, signals_VH});
+
+  // Background processes
+  /* // Not used in the function, keep it for documentation purposes.
+  std::vector<std::string> backgrounds = {"ZTT",  "W",   "ZL",      "ZJ",
+                                          "TTT",  "TTJ", "VVT",     "VVJ",
+                                          "EWKZ", "QCD", "jetFakes"};
+  */
+
+  // All processes being taken from simulation
+  // FIXME: Adapt for fake factor and embedding
+  std::vector<std::string> mc_processes =
+      JoinStr({
+              signals,
+              {"ZTT", "TTT", "VVT", "EWKZ", "W", "ZJ", "ZL", "TTJ", "VVJ"}
+              });
+
+  // ##########################################################################
+  // Uncertainty: Lumi
+  // References:
+  // - "CMS Luminosity Measurements for the 2016 Data Taking Period"
+  //   (PAS, https://cds.cern.ch/record/2257069)
+  // Notes:
+  // - FIXME: Adapt for fake factor and embedding
+  // ##########################################################################
+
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process(mc_processes)
+      .AddSyst(cb, "lumi_$ERA", "lnN", SystMap<>::init(1.025));
+
+  // ##########################################################################
+  // Uncertainty: Trigger efficiency
+  // References:
+  // Notes:
+  // - FIXME: References?
+  // ##########################################################################
+
+  cb.cp()
+      .channel({"et"})
+      .process(mc_processes)
+      .AddSyst(cb, "CMS_eff_trigger_et_$ERA", "lnN", SystMap<>::init(1.02));
+
+  cb.cp()
+      .channel({"mt"})
+      .process(mc_processes)
+      .AddSyst(cb, "CMS_eff_trigger_mt_$ERA", "lnN", SystMap<>::init(1.02));
+
+  cb.cp()
+      .channel({"tt"})
+      .process(mc_processes)
+      .AddSyst(cb, "CMS_eff_trigger_tt_$ERA", "lnN", SystMap<>::init(1.02));
+
+  // ##########################################################################
+  // Uncertainty: Electron, muon and tau ID efficiency
+  // References:
+  // Notes:
+  // - FIXME: Adapt for fake factor and embedding
+  // - FIXME: Handling of ZL in fully-hadronic channel?
+  // - FIXME: References?
+  // ##########################################################################
+
+  // Electron ID
+  cb.cp()
+      .channel({"et"})
+      .process(mc_processes)
+      .AddSyst(cb, "CMS_eff_e_$ERA", "lnN", SystMap<>::init(1.02));
+
+  // Muon ID
+  cb.cp()
+      .channel({"mt"})
+      .process(mc_processes)
+      .AddSyst(cb, "CMS_eff_m_$ERA", "lnN", SystMap<>::init(1.02));
+
+  // Tau ID: et and mt with 1 real tau
+  cb.cp()
+      .channel({"et", "mt"})
+      .process(mc_processes)
+      .AddSyst(cb, "CMS_eff_t_$ERA", "lnN", SystMap<>::init(1.045));
+
+  cb.cp()
+      .channel({"et", "mt"})
+      .process(mc_processes)
+      .AddSyst(cb, "CMS_eff_t_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.02));
+
+  // Tau ID: tt with 2 real taus
+  cb.cp()
+      .channel({"tt"})
+      .process({"ZTT", "TTT", "VVT", "EWKZ"})
+      .AddSyst(cb, "CMS_eff_t_$ERA", "lnN", SystMap<>::init(1.09));
+
+  cb.cp()
+      .channel({"tt"})
+      .process({"ZTT", "TTT", "VVT", "EWKZ"})
+      .AddSyst(cb, "CMS_eff_t_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.04));
+
+  // Tau ID: tt with 1 real taus and 1 jet fake
+  cb.cp()
+      .channel({"tt"})
+      .process({"W", "ZJ", "ZL", "TTJ", "VVJ"})
+      .AddSyst(cb, "CMS_eff_t_$ERA", "lnN", SystMap<>::init(1.06));
+
+  cb.cp()
+      .channel({"tt"})
+      .process({"W", "ZJ", "ZL", "TTJ", "VVJ"})
+      .AddSyst(cb, "CMS_eff_t_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.02));
+
+  // ##########################################################################
+  // Uncertainty: b-tag and mistag efficiency
+  // References:
+  // Notes:
+  // - FIXME: References?
+  // ##########################################################################
+
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process(mc_processes)
+      .AddSyst(cb, "CMS_htt_eff_b_$ERA", "shape", SystMap<>::init(1.00));
+
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process(mc_processes)
+      .AddSyst(cb, "CMS_htt_mistag_b_$ERA", "shape", SystMap<>::init(1.00));
+
+  // ##########################################################################
+  // Uncertainty: Tau energy scale
+  // References:
+  // Notes:
+  // - Tau energy scale is splitted by decay mode.
+  // - FIXME: References?
+  // ##########################################################################
+
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process(JoinStr({signals, {"ZTT", "TTT", "VVT", "EWKZ"}}))
+      .AddSyst(cb, "CMS_scale_t_1prong_$ERA", "shape", SystMap<>::init(1.00));
+
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process(JoinStr({signals, {"ZTT", "TTT", "VVT", "EWKZ"}}))
+      .AddSyst(cb, "CMS_scale_t_1prong1pizero_$ERA", "shape",
+               SystMap<>::init(1.00));
+
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process(JoinStr({signals, {"ZTT", "TTT", "VVT", "EWKZ"}}))
+      .AddSyst(cb, "CMS_scale_t_3prong_$ERA", "shape", SystMap<>::init(1.00));
+
+  // ##########################################################################
+  // Uncertainty: Jet energy scale
+  // References:
+  // Notes:
+  // - Current JES is inclusive. Splitted JES is to be implemented.
+  // - FIXME: References?
+  // ##########################################################################
+
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process(mc_processes)
+      .AddSyst(cb, "CMS_scale_j_$ERA", "shape", SystMap<>::init(1.00));
+
+  // ##########################################################################
+  // Uncertainty: MET energy scale
+  // References:
+  // Notes:
+  // - FIXME: Clustered vs unclustered MET? Inclusion of JES splitting?
+  // - FIXME: References?
+  // ##########################################################################
+
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process(mc_processes)
+      .AddSyst(cb, "CMS_scale_met_unclustered_$ERA", "shape", SystMap<>::init(1.00));
+
+  // ##########################################################################
+  // Uncertainty: Background normalizations
+  // References:
+  // Notes:
+  // - FIXME: Remeasure QCD extrapolation factors for SS and ABCD methods?
+  //          Current values are measured by KIT.
+  // - FIXME: Adapt for fake factor and embedding
+  // - FIXME: W uncertainties: Do we need lnN uncertainties based on the Ersatz
+  //          study in Run1 (found in HIG-16043 uncertainty model)
+  // - FIXME: References?
+  // ##########################################################################
+
+  // VV
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process({"VVT", "VVJ"})
+      .AddSyst(cb, "CMS_htt_vvXsec_$ERA", "lnN", SystMap<>::init(1.05));
+
+  // TT
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process({"TTT", "TTJ"})
+      .AddSyst(cb, "CMS_htt_tjXsec_$ERA", "lnN", SystMap<>::init(1.06));
+
+  // W
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process({"W"})
+      .AddSyst(cb, "CMS_htt_wjXsec_$ERA", "lnN", SystMap<>::init(1.04));
+
+  // Z
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process({"ZTT", "ZL", "ZJ"})
+      .AddSyst(cb, "CMS_htt_zjXsec_$ERA", "lnN", SystMap<>::init(1.04));
+
+  // QCD
+  cb.cp()
+      .channel({"et"})
+      .process({"QCD"})
+      .AddSyst(cb, "CMS_ExtrapSSOS_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.05));
+  cb.cp()
+      .channel({"mt"})
+      .process({"QCD"})
+      .AddSyst(cb, "CMS_ExtrapSSOS_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.03));
+  cb.cp()
+      .channel({"tt"})
+      .process({"QCD"})
+      .AddSyst(cb, "CMS_ExtrapABCD_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.03));
+
+  // ##########################################################################
+  // Uncertainty: Drell-Yan LO->NLO reweighting
+  // References:
+  // Notes:
+  // - FIXME: References?
+  // ##########################################################################
+
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process({"ZTT", "ZL", "ZJ"})
+      .AddSyst(cb, "CMS_htt_dyShape_$ERA", "shape", SystMap<>::init(1.00));
+
+  // ##########################################################################
+  // Uncertainty: TT shape reweighting
+  // References:
+  // Notes:
+  // - FIXME: References?
+  // ##########################################################################
+
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process({"TTT", "TTJ"})
+      .AddSyst(cb, "CMS_htt_ttbarShape_$ERA", "shape", SystMap<>::init(1.00));
+
+  // ##########################################################################
+  // Uncertainty: Electron/muon to tau fakes and ZL energy scale
+  // References:
+  // Notes:
+  // - FIXME: References?
+  // ##########################################################################
+
+  // ZL energy scale splitted by decay mode
+  cb.cp()
+      .channel({"et", "mt"})
+      .process({"ZL"})
+      .AddSyst(cb, "CMS_ZLShape_$CHANNEL_1prong_$ERA", "shape",
+               SystMap<>::init(1.00));
+
+  cb.cp()
+      .channel({"et", "mt"})
+      .process({"ZL"})
+      .AddSyst(cb, "CMS_ZLShape_$CHANNEL_1prong1pizero_$ERA", "shape",
+               SystMap<>::init(1.00));
+
+  // Electron fakes
+  cb.cp()
+      .channel({"et"})
+      .process({"ZL"})
+      .AddSyst(cb, "CMS_eFakeTau_1prong_$ERA", "shape", SystMap<>::init(1.00));
+
+  cb.cp()
+      .channel({"et"})
+      .process({"ZL"})
+      .AddSyst(cb, "CMS_eFakeTau_1prong1pizero_$ERA", "shape", SystMap<>::init(1.00));
+
+  // Muon fakes
+  cb.cp()
+      .channel({"mt"})
+      .process({"ZL"})
+      .AddSyst(cb, "CMS_mFakeTau_1prong_$ERA", "shape", SystMap<>::init(1.00));
+
+  cb.cp()
+      .channel({"mt"})
+      .process({"ZL"})
+      .AddSyst(cb, "CMS_mFakeTau_1prong1pizero_$ERA", "shape", SystMap<>::init(1.00));
+
+  // ##########################################################################
+  // Uncertainty: Jet to tau fakes
+  // References:
+  // Notes:
+  // - FIXME: Adapt for fake factor and embedding
+  // - FIXME: References?
+  // ##########################################################################
+
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process({"W", "TTJ", "ZJ", "VVJ"})
+      .AddSyst(cb, "CMS_htt_jetToTauFake_$ERA", "shape", SystMap<>::init(1.00));
+
+  // ##########################################################################
+  // Uncertainty: Theory uncertainties
+  // References:
+  // - STXS migration uncertainties:
+  //   https://indico.cern.ch/event/682466/contributions/2818245/attachments/1573067/2482834/2017-12-11_STXS.pdf
+  // Notes:
+  // - FIXME: Add STXS migration uncertainties
+  // - FIXME: Add TopMassTreatment from HIG-16043 uncertainty model
+  // - FIXME: Compare to HIG-16043 uncertainty model:
+  //           - PDF uncertainties splitted by category?
+  //           - QCDUnc uncertainties?
+  //           - UEPS uncertainties?
+  // - FIXME: References?
+  // ##########################################################################
+
+  // Uncertainty on branching ratio for HTT at 125 GeV
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process(signals)
+      .AddSyst(cb, "BR_htt_THU", "lnN", SystMap<>::init(1.017));
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process(signals)
+      .AddSyst(cb, "BR_htt_PU_mq", "lnN", SystMap<>::init(1.0099));
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process(signals)
+      .AddSyst(cb, "BR_htt_PU_alphas", "lnN", SystMap<>::init(1.0062));
+
+  // QCD scale
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process(signals_ggH)
+      .AddSyst(cb, "QCDScale_ggH", "lnN", SystMap<>::init(1.039));
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process(signals_qqH)
+      .AddSyst(cb, "QCDScale_qqH", "lnN", SystMap<>::init(1.004));
+
+  // PDF
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process(signals_ggH)
+      .AddSyst(cb, "pdf_Higgs_gg", "lnN", SystMap<>::init(1.032));
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process(signals_qqH)
+      .AddSyst(cb, "pdf_Higgs_qq", "lnN", SystMap<>::init(1.021));
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process({"WH_htt"})
+      .AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.019));
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process({"ZH_htt"})
+      .AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.016));
+
+  // ##########################################################################
+  // Uncertainty: Jet fakes
+  // References:
+  // Notes:
+  // - FIXME: Add log-normal uncertainties for all categories
+  // - FIXME: References?
+  // ##########################################################################
+
+  // QCD norm stat.
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process({"jetFakes"})
+      .AddSyst(cb, "CMS_htt_norm_ff_qcd_1prong_njet0_$CHANNEL_stat_$ERA", "shape", SystMap<>::init(1.00));
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process({"jetFakes"})
+      .AddSyst(cb, "CMS_htt_norm_ff_qcd_1prong_njet1_$CHANNEL_stat_$ERA", "shape", SystMap<>::init(1.00));
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process({"jetFakes"})
+      .AddSyst(cb, "CMS_htt_norm_ff_qcd_3prong_njet0_$CHANNEL_stat_$ERA", "shape", SystMap<>::init(1.00));
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process({"jetFakes"})
+      .AddSyst(cb, "CMS_htt_norm_ff_qcd_3prong_njet1_$CHANNEL_stat_$ERA", "shape", SystMap<>::init(1.00));
+
+  // W norm stat.
+  cb.cp()
+      .channel({"et", "mt"})
+      .process({"jetFakes"})
+      .AddSyst(cb, "CMS_htt_norm_ff_w_1prong_njet0_$CHANNEL_stat_$ERA", "shape", SystMap<>::init(1.00));
+  cb.cp()
+      .channel({"et", "mt"})
+      .process({"jetFakes"})
+      .AddSyst(cb, "CMS_htt_norm_ff_w_1prong_njet1_$CHANNEL_stat_$ERA", "shape", SystMap<>::init(1.00));
+  cb.cp()
+      .channel({"et", "mt"})
+      .process({"jetFakes"})
+      .AddSyst(cb, "CMS_htt_norm_ff_w_3prong_njet0_$CHANNEL_stat_$ERA", "shape", SystMap<>::init(1.00));
+  cb.cp()
+      .channel({"et", "mt"})
+      .process({"jetFakes"})
+      .AddSyst(cb, "CMS_htt_norm_ff_w_3prong_njet1_$CHANNEL_stat_$ERA", "shape", SystMap<>::init(1.00));
+
+  // TT norm stat.
+  cb.cp()
+      .channel({"et", "mt"})
+      .process({"jetFakes"})
+      .AddSyst(cb, "CMS_htt_norm_ff_tt_1prong_njet0_stat_$ERA", "shape", SystMap<>::init(1.00));
+  cb.cp()
+      .channel({"et", "mt"})
+      .process({"jetFakes"})
+      .AddSyst(cb, "CMS_htt_norm_ff_tt_1prong_njet1_stat_$ERA", "shape", SystMap<>::init(1.00));
+  cb.cp()
+      .channel({"et", "mt"})
+      .process({"jetFakes"})
+      .AddSyst(cb, "CMS_htt_norm_ff_tt_3prong_njet0_stat_$ERA", "shape", SystMap<>::init(1.00));
+  cb.cp()
+      .channel({"et", "mt"})
+      .process({"jetFakes"})
+      .AddSyst(cb, "CMS_htt_norm_ff_tt_3prong_njet1_stat_$ERA", "shape", SystMap<>::init(1.00));
+
+  // Norm syst.
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process({"jetFakes"})
+      .AddSyst(cb, "CMS_htt_norm_ff_qcd_$CHANNEL_syst_$ERA", "shape", SystMap<>::init(1.00));
+  cb.cp()
+      .channel({"et", "mt"})
+      .process({"jetFakes"})
+      .AddSyst(cb, "CMS_htt_norm_ff_w_syst_$ERA", "shape", SystMap<>::init(1.00));
+  cb.cp()
+      .channel({"et", "mt"})
+      .process({"jetFakes"})
+      .AddSyst(cb, "CMS_htt_norm_ff_tt_syst_$ERA", "shape", SystMap<>::init(1.00));
+  cb.cp()
+      .channel({"tt"})
+      .process({"jetFakes"})
+      .AddSyst(cb, "CMS_htt_norm_ff_w_$CHANNEL_syst_$ERA", "shape", SystMap<>::init(1.00));
+  cb.cp()
+      .channel({"tt"})
+      .process({"jetFakes"})
+      .AddSyst(cb, "CMS_htt_norm_ff_ttbar_$CHANNEL_syst_$ERA", "shape", SystMap<>::init(1.00));
+
+  // Stat. norm
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process({"jetFakes"})
+      .AddSyst(cb, "CMS_htt_ff_norm_stat_$CHANNEL_$BIN_$ERA", "lnN",
+               SystMap<channel, bin_id>::init
+                    ({"mt"}, {1}, 1.04)
+                    ({"mt"}, {2}, 1.03)
+                    ({"mt"}, {3}, 1.045)
+                    ({"et"}, {1}, 1.04)
+                    ({"et"}, {2}, 1.05)
+                    ({"et"}, {3}, 1.065)
+                    ({"tt"}, {1}, 1.03)
+                    ({"tt"}, {2}, 1.04)
+                    ({"tt"}, {3}, 1.05));
+
+  // Syst. norm: Bin-correlated
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process({"jetFakes"})
+      .AddSyst(cb, "CMS_htt_ff_norm_syst_$CHANNEL_$ERA", "lnN",
+               SystMap<channel, bin_id>::init
+                    ({"mt"}, {1}, 1.065)
+                    ({"mt"}, {2}, 1.062)
+                    ({"mt"}, {3}, 1.078)
+                    ({"et"}, {1}, 1.073)
+                    ({"et"}, {2}, 1.067)
+                    ({"et"}, {3}, 1.083)
+                    ({"tt"}, {1}, 1.026)
+                    ({"tt"}, {2}, 1.032)
+                    ({"tt"}, {3}, 1.040));
+  // Syst. norm: Bin-dependent
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process({"jetFakes"})
+      .AddSyst(cb, "CMS_htt_ff_sub_syst_$CHANNEL_$BIN_$ERA", "lnN",
+          SystMap<channel, bin_id>::init
+                    ({"mt"}, {1}, 1.06)
+                    ({"mt"}, {2}, 1.04)
+                    ({"mt"}, {3}, 1.04)
+                    ({"et"}, {1}, 1.06)
+                    ({"et"}, {2}, 1.04)
+                    ({"et"}, {3}, 1.04)
+                    ({"tt"}, {1}, 1.06)
+                    ({"tt"}, {2}, 1.04));
+}
 } // namespace ch

--- a/HTTSM2017/src/HttSystematics_SMRun2.cc
+++ b/HTTSM2017/src/HttSystematics_SMRun2.cc
@@ -28,14 +28,14 @@ namespace ch {
 
         std::vector<std::string> all_mc_bkgs = {
             "ZL","ZJ","ZTT","TTJ","TTT","TT",
-            "W","VV","VVT","VVJ",
+            "W","W_rest","ZJ_rest","TTJ_rest","VVJ_rest","VV","VVT","VVJ",
             "ggH_hww125","qqH_hww125","EWKZ"};
         std::vector<std::string> all_mc_bkgs_truetau = {
             "ZTT","TTT","TT","VV","VVT",
             "ggH_hww125","qqH_hww125","EWKZ"};
         std::vector<std::string> all_mc_bkgs_no_W = {
             "ZL","ZJ","ZTT","TTJ","TTT","TT",
-            "VV","VVT","VVJ",
+            "ZJ_rest","TTJ_rest","VVJ_rest","VV","VVT","VVJ",
             "ggH_hww125","qqH_hww125","EWKZ"};
 
         //##############################################################################
@@ -44,6 +44,7 @@ namespace ch {
 
         cb.cp().process(JoinStr({sig_procs, {"VV","VVT","VVJ","ggH_hww125","qqH_hww125"}})).AddSyst(cb,
                                             "lumi_13TeV", "lnN", SystMap<>::init(1.025));
+        cb.cp().process({"W_rest", "ZJ_rest", "TTJ_rest", "VVJ_rest"}).channel({"tt"}).AddSyst(cb,"lumi_13TeV", "lnN", SystMap<>::init(1.025));
 
         //Add luminosity uncertainty for W in em, tt, ttbar and the mm region as norm is from MC // FIXME: This does not make sense anymore.
         cb.cp().process({"W"}).channel({"tt","em","mm","ttbar"}).AddSyst(cb,
@@ -100,10 +101,10 @@ namespace ch {
                                              "CMS_eff_t_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.04));
 
         // TauTau - 1+ jet to tau fakes
-        cb.cp().process({"TTJ","ZJ","VVJ","W"}).channel({"tt"}).AddSyst(cb,
+        cb.cp().process({"TTJ","ZJ","VVJ","W","W_rest","ZJ_rest","TTJ_rest","VVJ_rest"}).channel({"tt"}).AddSyst(cb,
                                              "CMS_eff_t_$ERA", "lnN", SystMap<>::init(1.06));
 
-        cb.cp().process({"TTJ","ZJ","VVJ","W"}).channel({"tt"}).AddSyst(cb,
+        cb.cp().process({"TTJ","ZJ","VVJ","W","W_rest","ZJ_rest","TTJ_rest","VVJ_rest"}).channel({"tt"}).AddSyst(cb,
                                              "CMS_eff_t_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.02));
 
         //######################## Tau Id shape uncertainty (added March 08)
@@ -228,10 +229,10 @@ namespace ch {
         //##############################################################################
 
         //   Diboson  Normalisation - fully correlated
-        cb.cp().process({"VV","VVT","VVJ"}).AddSyst(cb,
+        cb.cp().process({"VV","VVT","VVJ","VVJ_rest"}).AddSyst(cb,
                                         "CMS_htt_vvXsec_13TeV", "lnN", SystMap<>::init(1.05));
         //   ttbar Normalisation - fully correlated
-	    cb.cp().process({"TT","TTT","TTJ"}).AddSyst(cb,
+	    cb.cp().process({"TT","TTT","TTJ","TTJ_rest"}).AddSyst(cb,
 					  "CMS_htt_tjXsec_13TeV", "lnN", SystMap<>::init(1.06));
 
         // W norm, just for em, tt and the mm region where MC norm is from MC // FIXME: This needs to be done everywhere.
@@ -292,7 +293,7 @@ namespace ch {
         //  DY LO->NLO reweighting, Between no and twice the correction.
         //##############################################################################
 
-        cb.cp().process( {"ZTT","ZJ","ZL"}).channel({"et","mt","tt"}).AddSyst(cb,
+        cb.cp().process( {"ZTT","ZJ","ZL","ZJ_rest"}).channel({"et","mt","tt"}).AddSyst(cb,
                                              "CMS_htt_dyShape_$ERA", "shape", SystMap<>::init(1.00));
         cb.cp().process( {"ZTT","ZL"}).channel({"em"}).AddSyst(cb,
                                              "CMS_htt_dyShape_$ERA", "shape", SystMap<>::init(1.00));
@@ -302,7 +303,7 @@ namespace ch {
         // Ttbar shape reweighting, Between no and twice the correction
         //##############################################################################
 
-        cb.cp().process( {"TTJ","TTT"}).channel({"tt"}).AddSyst(cb,
+        cb.cp().process( {"TTJ","TTT","TTJ_rest"}).channel({"tt"}).AddSyst(cb,
                                         "CMS_htt_ttbarShape_$ERA", "shape", SystMap<>::init(1.00));
         cb.cp().process( {"TTJ","TTT"}).channel({"et","mt"}).AddSyst(cb,
                                         "CMS_htt_ttbarShape_$ERA", "shape", SystMap<>::init(1.00));
@@ -332,7 +333,7 @@ namespace ch {
         // jet  to tau fake only in tt, mt and et channels
         //##############################################################################
 
-        cb.cp().process( {"TTJ","ZJ","VVJ"}).channel({"tt","mt","et"}).AddSyst(cb,
+        cb.cp().process( {"TTJ","ZJ","VVJ","W_rest","ZJ_rest","TTJ_rest","VVJ_rest"}).channel({"tt","mt","et"}).AddSyst(cb,
                                                                             "CMS_htt_jetToTauFake_$ERA", "shape", SystMap<>::init(1.00));
 
         // FIXME: This does not make sense anymore?
@@ -586,40 +587,40 @@ namespace ch {
 
             // Z->mumu CR normalization propagation // FIXME: This does not make sense anymore
             // 0jet normalization only
-            cb.cp().process({"ZTT", "ZL", "ZJ", "EWKZ"}).AddSyst(cb,
+            cb.cp().process({"ZTT", "ZL", "ZJ", "ZJ_rest", "EWKZ"}).AddSyst(cb,
                                              "CMS_htt_zmm_norm_extrap_0jet_$CHANNEL_$ERA", "lnN",
                                              SystMap<channel, bin_id>::init({"em","tt"},{1}, 1.07));
-            cb.cp().process({"ZTT", "ZL", "ZJ", "EWKZ"}).AddSyst(cb,
+            cb.cp().process({"ZTT", "ZL", "ZJ", "ZJ_rest", "EWKZ"}).AddSyst(cb,
                                              "CMS_htt_zmm_norm_extrap_0jet_lt_$ERA", "lnN",
                                              SystMap<channel, bin_id>::init({"et","mt"},{1}, 1.07));
 
             // boosted normalization only
-            cb.cp().process({"ZTT", "ZL", "ZJ", "EWKZ"}).AddSyst(cb,
+            cb.cp().process({"ZTT", "ZL", "ZJ", "ZJ_rest", "EWKZ"}).AddSyst(cb,
                                              "CMS_htt_zmm_norm_extrap_boosted_$CHANNEL_$ERA", "lnN",
                                              SystMap<channel, bin_id>::init({"em","tt"},{2}, 1.07));
-            cb.cp().process({"ZTT", "ZL", "ZJ", "EWKZ"}).AddSyst(cb,
+            cb.cp().process({"ZTT", "ZL", "ZJ", "ZJ_rest", "EWKZ"}).AddSyst(cb,
                                              "CMS_htt_zmm_norm_extrap_boosted_lt_$ERA", "lnN",
                                              SystMap<channel, bin_id>::init({"et","mt"},{2}, 1.07));
 
             // VBF norm and shape for et/mt/tt
-            cb.cp().process( {"ZL","ZTT","ZJ", "EWKZ"}).channel({"em"}).bin_id({3}).AddSyst(cb,
+            cb.cp().process( {"ZL","ZTT","ZJ", "ZJ_rest", "EWKZ"}).channel({"em"}).bin_id({3}).AddSyst(cb,
                                              "CMS_htt_zmm_norm_extrap_VBF_em_$ERA", "lnN", SystMap<>::init(1.15));
-            cb.cp().process( {"ZL","ZTT","ZJ", "EWKZ"}).channel({"et","mt"}).bin_id({3}).AddSyst(cb,
+            cb.cp().process( {"ZL","ZTT","ZJ", "ZJ_rest", "EWKZ"}).channel({"et","mt"}).bin_id({3}).AddSyst(cb,
                                              "CMS_htt_zmm_norm_extrap_VBF_lt_$ERA", "lnN", SystMap<>::init(1.15));
-            cb.cp().process( {"ZL","ZTT","ZJ", "EWKZ"}).channel({"tt"}).bin_id({3}).AddSyst(cb,
+            cb.cp().process( {"ZL","ZTT","ZJ", "ZJ_rest", "EWKZ"}).channel({"tt"}).bin_id({3}).AddSyst(cb,
                                              "CMS_htt_zmm_norm_extrap_VBF_tt_$ERA", "lnN", SystMap<>::init(1.10));
 
 //            // FIXME should have EWKZ in all // FIXME: This is important for us?
-//            cb.cp().process( {"ZL","ZTT","ZJ", "EWKZ"}).channel({"tt"}).bin_id({3}).AddSyst(cb,
+//            cb.cp().process( {"ZL","ZTT","ZJ", "ZJ_rest", "EWKZ"}).channel({"tt"}).bin_id({3}).AddSyst(cb,
 //                                             "CMS_htt_zmumuShape_VBF_$ERA", "shape", SystMap<>::init(1.00));
-//            cb.cp().process( {"ZL","ZTT","ZJ", "EWKZ"}).channel({"mt","et"}).bin_id({3}).AddSyst(cb,
+//            cb.cp().process( {"ZL","ZTT","ZJ", "ZJ_rest", "EWKZ"}).channel({"mt","et"}).bin_id({3}).AddSyst(cb,
 //                                             "CMS_htt_zmumuShape_VBF_$ERA", "shape", SystMap<>::init(1.00));
-//            cb.cp().process( {"ZL","ZTT","ZJ"}).channel({"em"}).bin_id({3}).AddSyst(cb,
+//            cb.cp().process( {"ZL","ZTT","ZJ", "ZJ_rest"}).channel({"em"}).bin_id({3}).AddSyst(cb,
 //                                            "CMS_htt_zmumuShape_VBF_$ERA", "shape", SystMap<>::init(1.00));
 
-            cb.cp().process( {"ZL","ZTT","ZJ", "EWKZ"}).channel({"tt","et","mt"}).bin_id({3}).AddSyst(cb,
+            cb.cp().process( {"ZL","ZTT","ZJ", "ZJ_rest", "EWKZ"}).channel({"tt","et","mt"}).bin_id({3}).AddSyst(cb,
                                             "CMS_htt_zmumuShape_VBF_$ERA", "shape", SystMap<>::init(1.00));
-            cb.cp().process( {"ZL","ZTT","ZJ" }).channel({"em"}).bin_id({3}).AddSyst(cb,
+            cb.cp().process( {"ZL","ZTT","ZJ", "ZJ_rest"}).channel({"em"}).bin_id({3}).AddSyst(cb,
                                             "CMS_htt_zmumuShape_VBF_$ERA", "shape", SystMap<>::init(1.00));
 
 	//jet fakes: shape uncertainties


### PR DESCRIPTION
- add embedding and fake factor options for building uncertainty model
- add facility to set different STXS signals and categories
- integrate changes of cms-analysis/CombineHarvester/SMHTT2017-dev (readd VV for tt channel, removing _rest categories)
- restructure and comment declaration of uncertainties in HttSystematics_SMRun2.cc