### PR TITLE
 [SMHTT2017-dev] Added uncertainty model for embedded events

### DIFF
--- a/HTTSM2017/bin/MorphingSM2017.cpp
+++ b/HTTSM2017/bin/MorphingSM2017.cpp
@@ -206,8 +206,14 @@ int main(int argc, char **argv) {
   // - https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHXSWGFiducialAndSTXS
   // - https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHXSWG2
   else if(stxs_signals == 1) sig_procs = {
-      "ggH_0J", "ggH_1J", "ggH_GE2J", "ggH_VBFTOPO",
-      "qqH_VBFTOPO_JET3", "qqH_VBFTOPO_JET3VETO", "qqH_REST", "qqH_PTJET1_GT200"};
+      // ggH
+      "ggH_0J", "ggH_1J_PTH_0_60", "ggH_1J_PTH_60_120", "ggH_1J_PTH_120_200",
+      "ggH_1J_PTH_GT200", "ggH_GE2J_PTH_0_60", "ggH_GE2J_PTH_60_120",
+      "ggH_GE2J_PTH_120_200", "ggH_GE2J_PTH_GT200", "ggH_VBFTOPO_JET3VETO",
+      "ggH_VBFTOPO_JET3",
+      // VBF
+      "qqH_VBFTOPO_JET3VETO", "qqH_VBFTOPO_JET3", "qqH_REST",
+      "qqH_PTJET1_GT200", "qqH_VH2JET"};
   else throw std::runtime_error("Given STXS signals are not known.");
   vector<string> masses = {"125"};
 

--- a/HTTSM2017/bin/MorphingSM2017.cpp
+++ b/HTTSM2017/bin/MorphingSM2017.cpp
@@ -33,6 +33,7 @@ int main(int argc, char **argv) {
   typedef vector<string> VString;
   typedef vector<pair<int, string>> Categories;
   using ch::syst::bin_id;
+  using ch::JoinStr;
 
   // Define program options
   string output_folder = "sm_run2";
@@ -103,17 +104,31 @@ int main(int argc, char **argv) {
 
   // Define background processes
   map<string, VString> bkg_procs;
-  if (jetfakes) {
-    bkg_procs["et"] = {"ZTT", "ZL", "TTT", "VVT", "EWKZ", "jetFakes"};
-    bkg_procs["mt"] = {"ZTT", "ZL", "TTT", "VVT", "EWKZ", "jetFakes"};
-    bkg_procs["tt"] = {"ZTT", "ZL", "TTT", "VVT", "EWKZ", "jetFakes"};
-    bkg_procs["em"] = {"ZTT", "ZL", "TTT", "VVT", "EWKZ", "jetFakes"};
-  } else {
-    bkg_procs["et"] = {"W", "ZTT", "QCD", "ZL", "ZJ", "TTT", "TTJ", "VVJ", "VVT", "EWKZ"};
-    bkg_procs["mt"] = {"W", "ZTT", "QCD", "ZL", "ZJ", "TTT", "TTJ", "VVJ", "VVT", "EWKZ"};
-    bkg_procs["tt"] = {"W", "ZTT", "QCD", "ZL", "ZJ", "TTT", "TTJ", "VVJ", "VVT", "EWKZ"};
-    bkg_procs["em"] = {"W", "ZTT", "QCD", "ZL", "ZJ", "TTT", "TTJ", "VVJ", "VVT", "EWKZ"};
+  VString bkgs;
+  bkgs = {"W", "ZTT", "QCD", "ZL", "ZJ", "TTT", "TTJ", "VVJ", "VVT", "EWKZ"};
+  if(embedding){
+      bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "ZTT"), bkgs.end());
+      bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "TTT"), bkgs.end());
+      bkgs = JoinStr({bkgs,{"EMB","TTL"}});
   }
+  if(jetfakes){
+      bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "QCD"), bkgs.end());
+      bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "W"), bkgs.end());
+      bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "VVJ"), bkgs.end());
+      bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "TTJ"), bkgs.end());
+      bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "ZJ"), bkgs.end());
+      bkgs = JoinStr({bkgs,{"jetFakes"}});
+  }
+  
+  std::cout << "[INFO] Considerung the following processes:\n";
+  for (unsigned int i=0; i < bkgs.size(); i++) {
+  std::cout << bkgs[i] << " ";
+  }
+  std::cout << std::endl;
+  bkg_procs["et"] = bkgs;
+  bkg_procs["mt"] = bkgs;
+  bkg_procs["tt"] = bkgs;
+  bkg_procs["em"] = bkgs;
 
   // Define categories
   map<string, Categories> cats;

--- a/HTTSM2017/bin/MorphingSM2017.cpp
+++ b/HTTSM2017/bin/MorphingSM2017.cpp
@@ -153,12 +153,8 @@ int main(int argc, char **argv) {
   // STXS stage 1 categories (optimized on STXS stage 1 splits of ggH and VBF)
   else if(stxs_categories == 1){
     cats["et"] = {
-        { 3, "et_ggh_0jet"},
-        { 4, "et_ggh_1jet"},
-        { 5, "et_ggh_ge2jets"},
-        { 6, "et_qqh_l2jets"},
-        { 7, "et_qqh_2jets"},
-        { 8, "et_qqh_g2jets"},
+        { 1, "et_ggh_unrolled"},
+        { 2, "et_qqh_unrolled"},
         {11, "et_w"},
         {12, "et_ztt"},
         {13, "et_tt"},
@@ -167,12 +163,8 @@ int main(int argc, char **argv) {
         {16, "et_misc"},
     };
      cats["mt"] = {
-        { 3, "mt_ggh_0jet"},
-        { 4, "mt_ggh_1jet"},
-        { 5, "mt_ggh_ge2jets"},
-        { 6, "mt_qqh_l2jets"},
-        { 7, "mt_qqh_2jets"},
-        { 8, "mt_qqh_g2jets"},
+        { 1, "mt_ggh_unrolled"},
+        { 2, "mt_qqh_unrolled"},
         {11, "mt_w"},
         {12, "mt_ztt"},
         {13, "mt_tt"},
@@ -181,12 +173,8 @@ int main(int argc, char **argv) {
         {16, "mt_misc"},
     };
      cats["tt"] = {
-        { 3, "tt_ggh_0jet"},
-        { 4, "tt_ggh_1jet"},
-        { 5, "tt_ggh_ge2jets"},
-        { 6, "tt_qqh_l2jets"},
-        { 7, "tt_qqh_2jets"},
-        { 8, "tt_qqh_g2jets"},
+        { 1, "tt_ggh_unrolled"},
+        { 2, "tt_qqh_unrolled"},
         {12, "tt_ztt"},
         {16, "tt_misc"},
         {17, "tt_noniso"},

--- a/HTTSM2017/src/HttSystematics_SMRun2.cc
+++ b/HTTSM2017/src/HttSystematics_SMRun2.cc
@@ -32,12 +32,16 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding) {
       // STXS stage 0
       "ggH",
       // STXS stage 1
-      "ggH_0J", "ggH_1J", "ggH_GE2J", "ggH_VBFTOPO"};
+      "ggH_0J", "ggH_1J_PTH_0_60", "ggH_1J_PTH_60_120", "ggH_1J_PTH_120_200",
+      "ggH_1J_PTH_GT200", "ggH_GE2J_PTH_0_60", "ggH_GE2J_PTH_60_120",
+      "ggH_GE2J_PTH_120_200", "ggH_GE2J_PTH_GT200", "ggH_VBFTOPO_JET3VETO",
+      "ggH_VBFTOPO_JET3"};
   std::vector<std::string> signals_qqH = {
       // STXS stage 0
       "qqH"
       // STXS stage 1
-      "qqH_VBFTOPO_JET3", "qqH_VBFTOPO_JET3VETO", "qqH_REST", "qqH_PTJET1_GT200"};
+      "qqH_VBFTOPO_JET3VETO", "qqH_VBFTOPO_JET3", "qqH_REST",
+      "qqH_PTJET1_GT200", "qqH_VH2JET"};
   std::vector<std::string> signals_VH = {
       // STXS stage 0
       "WH_htt", "ZH_htt"};
@@ -421,131 +425,103 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding) {
   // ##########################################################################
   // Uncertainty: Jet fakes
   // References:
+  // - https://twiki.cern.ch/twiki/bin/viewauth/CMS/HiggsToTauTauJet2TauFakes
   // Notes:
   // - FIXME: Add log-normal uncertainties for all categories
-  // - FIXME: References?
   // ##########################################################################
 
   // QCD norm stat.
   cb.cp()
       .channel({"et", "mt", "tt"})
       .process({"jetFakes"})
-      .AddSyst(cb, "CMS_htt_norm_ff_qcd_1prong_njet0_$CHANNEL_stat_$ERA", "shape", SystMap<>::init(1.00));
+      .AddSyst(cb, "CMS_ff_qcd_dm0_njet0_$CHANNEL_stat_$ERA", "shape", SystMap<>::init(1.00));
   cb.cp()
       .channel({"et", "mt", "tt"})
       .process({"jetFakes"})
-      .AddSyst(cb, "CMS_htt_norm_ff_qcd_1prong_njet1_$CHANNEL_stat_$ERA", "shape", SystMap<>::init(1.00));
+      .AddSyst(cb, "CMS_ff_qcd_dm0_njet1_$CHANNEL_stat_$ERA", "shape", SystMap<>::init(1.00));
   cb.cp()
       .channel({"et", "mt", "tt"})
       .process({"jetFakes"})
-      .AddSyst(cb, "CMS_htt_norm_ff_qcd_3prong_njet0_$CHANNEL_stat_$ERA", "shape", SystMap<>::init(1.00));
+      .AddSyst(cb, "CMS_ff_qcd_dm1_njet0_$CHANNEL_stat_$ERA", "shape", SystMap<>::init(1.00));
   cb.cp()
       .channel({"et", "mt", "tt"})
       .process({"jetFakes"})
-      .AddSyst(cb, "CMS_htt_norm_ff_qcd_3prong_njet1_$CHANNEL_stat_$ERA", "shape", SystMap<>::init(1.00));
+      .AddSyst(cb, "CMS_ff_qcd_dm1_njet1_$CHANNEL_stat_$ERA", "shape", SystMap<>::init(1.00));
 
   // W norm stat.
   cb.cp()
       .channel({"et", "mt"})
       .process({"jetFakes"})
-      .AddSyst(cb, "CMS_htt_norm_ff_w_1prong_njet0_$CHANNEL_stat_$ERA", "shape", SystMap<>::init(1.00));
+      .AddSyst(cb, "CMS_ff_w_dm0_njet0_$CHANNEL_stat_$ERA", "shape", SystMap<>::init(1.00));
   cb.cp()
       .channel({"et", "mt"})
       .process({"jetFakes"})
-      .AddSyst(cb, "CMS_htt_norm_ff_w_1prong_njet1_$CHANNEL_stat_$ERA", "shape", SystMap<>::init(1.00));
+      .AddSyst(cb, "CMS_ff_w_dm0_njet1_$CHANNEL_stat_$ERA", "shape", SystMap<>::init(1.00));
   cb.cp()
       .channel({"et", "mt"})
       .process({"jetFakes"})
-      .AddSyst(cb, "CMS_htt_norm_ff_w_3prong_njet0_$CHANNEL_stat_$ERA", "shape", SystMap<>::init(1.00));
+      .AddSyst(cb, "CMS_ff_w_dm1_njet0_$CHANNEL_stat_$ERA", "shape", SystMap<>::init(1.00));
   cb.cp()
       .channel({"et", "mt"})
       .process({"jetFakes"})
-      .AddSyst(cb, "CMS_htt_norm_ff_w_3prong_njet1_$CHANNEL_stat_$ERA", "shape", SystMap<>::init(1.00));
+      .AddSyst(cb, "CMS_ff_w_dm1_njet1_$CHANNEL_stat_$ERA", "shape", SystMap<>::init(1.00));
 
   // TT norm stat.
   cb.cp()
       .channel({"et", "mt"})
       .process({"jetFakes"})
-      .AddSyst(cb, "CMS_htt_norm_ff_tt_1prong_njet0_stat_$ERA", "shape", SystMap<>::init(1.00));
+      .AddSyst(cb, "CMS_ff_tt_dm0_njet0_stat_$ERA", "shape", SystMap<>::init(1.00));
   cb.cp()
       .channel({"et", "mt"})
       .process({"jetFakes"})
-      .AddSyst(cb, "CMS_htt_norm_ff_tt_1prong_njet1_stat_$ERA", "shape", SystMap<>::init(1.00));
+      .AddSyst(cb, "CMS_ff_tt_dm0_njet1_stat_$ERA", "shape", SystMap<>::init(1.00));
   cb.cp()
       .channel({"et", "mt"})
       .process({"jetFakes"})
-      .AddSyst(cb, "CMS_htt_norm_ff_tt_3prong_njet0_stat_$ERA", "shape", SystMap<>::init(1.00));
+      .AddSyst(cb, "CMS_ff_tt_dm1_njet0_stat_$ERA", "shape", SystMap<>::init(1.00));
   cb.cp()
       .channel({"et", "mt"})
       .process({"jetFakes"})
-      .AddSyst(cb, "CMS_htt_norm_ff_tt_3prong_njet1_stat_$ERA", "shape", SystMap<>::init(1.00));
+      .AddSyst(cb, "CMS_ff_tt_dm1_njet1_stat_$ERA", "shape", SystMap<>::init(1.00));
 
   // Norm syst.
   cb.cp()
       .channel({"et", "mt", "tt"})
       .process({"jetFakes"})
-      .AddSyst(cb, "CMS_htt_norm_ff_qcd_$CHANNEL_syst_$ERA", "shape", SystMap<>::init(1.00));
+      .AddSyst(cb, "CMS_ff_qcd_$CHANNEL_syst_$ERA", "shape", SystMap<>::init(1.00));
   cb.cp()
       .channel({"et", "mt"})
       .process({"jetFakes"})
-      .AddSyst(cb, "CMS_htt_norm_ff_w_syst_$ERA", "shape", SystMap<>::init(1.00));
+      .AddSyst(cb, "CMS_ff_w_syst_$ERA", "shape", SystMap<>::init(1.00));
   cb.cp()
       .channel({"et", "mt"})
       .process({"jetFakes"})
-      .AddSyst(cb, "CMS_htt_norm_ff_tt_syst_$ERA", "shape", SystMap<>::init(1.00));
+      .AddSyst(cb, "CMS_ff_tt_syst_$ERA", "shape", SystMap<>::init(1.00));
   cb.cp()
       .channel({"tt"})
       .process({"jetFakes"})
-      .AddSyst(cb, "CMS_htt_norm_ff_w_$CHANNEL_syst_$ERA", "shape", SystMap<>::init(1.00));
+      .AddSyst(cb, "CMS_ff_w_$CHANNEL_syst_$ERA", "shape", SystMap<>::init(1.00));
   cb.cp()
       .channel({"tt"})
       .process({"jetFakes"})
-      .AddSyst(cb, "CMS_htt_norm_ff_ttbar_$CHANNEL_syst_$ERA", "shape", SystMap<>::init(1.00));
+      .AddSyst(cb, "CMS_ff_tt_$CHANNEL_syst_$ERA", "shape", SystMap<>::init(1.00));
 
   // Stat. norm
   cb.cp()
       .channel({"et", "mt", "tt"})
       .process({"jetFakes"})
-      .AddSyst(cb, "CMS_htt_ff_norm_stat_$CHANNEL_$BIN_$ERA", "lnN",
-               SystMap<channel, bin_id>::init
-                    ({"mt"}, {1}, 1.04)
-                    ({"mt"}, {2}, 1.03)
-                    ({"mt"}, {3}, 1.045)
-                    ({"et"}, {1}, 1.04)
-                    ({"et"}, {2}, 1.05)
-                    ({"et"}, {3}, 1.065)
-                    ({"tt"}, {1}, 1.03)
-                    ({"tt"}, {2}, 1.04)
-                    ({"tt"}, {3}, 1.05));
+      .AddSyst(cb, "CMS_ff_norm_stat_$CHANNEL_$BIN_$ERA", "lnN", SystMap<>::init(1.05));
 
   // Syst. norm: Bin-correlated
   cb.cp()
       .channel({"et", "mt", "tt"})
       .process({"jetFakes"})
-      .AddSyst(cb, "CMS_htt_ff_norm_syst_$CHANNEL_$ERA", "lnN",
-               SystMap<channel, bin_id>::init
-                    ({"mt"}, {1}, 1.065)
-                    ({"mt"}, {2}, 1.062)
-                    ({"mt"}, {3}, 1.078)
-                    ({"et"}, {1}, 1.073)
-                    ({"et"}, {2}, 1.067)
-                    ({"et"}, {3}, 1.083)
-                    ({"tt"}, {1}, 1.026)
-                    ({"tt"}, {2}, 1.032)
-                    ({"tt"}, {3}, 1.040));
+      .AddSyst(cb, "CMS_ff_norm_syst_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.05));
+
   // Syst. norm: Bin-dependent
   cb.cp()
       .channel({"et", "mt", "tt"})
       .process({"jetFakes"})
-      .AddSyst(cb, "CMS_htt_ff_sub_syst_$CHANNEL_$BIN_$ERA", "lnN",
-          SystMap<channel, bin_id>::init
-                    ({"mt"}, {1}, 1.06)
-                    ({"mt"}, {2}, 1.04)
-                    ({"mt"}, {3}, 1.04)
-                    ({"et"}, {1}, 1.06)
-                    ({"et"}, {2}, 1.04)
-                    ({"et"}, {3}, 1.04)
-                    ({"tt"}, {1}, 1.06)
-                    ({"tt"}, {2}, 1.04));
+      .AddSyst(cb, "CMS_ff_sub_syst_$CHANNEL_$BIN_$ERA", "lnN", SystMap<>::init(1.05));
 }
 } // namespace ch

--- a/HTTSM2017/src/HttSystematics_SMRun2.cc
+++ b/HTTSM2017/src/HttSystematics_SMRun2.cc
@@ -19,9 +19,6 @@ using ch::syst::bin;
 using ch::JoinStr;
 
 void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding) {
-  // Error-handling
-  if (embedding)
-    throw std::runtime_error("Embedding is not yet implemented.");
 
   // ##########################################################################
   // Define groups of processes
@@ -51,7 +48,7 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding) {
   /* // Not used in the function, keep it for documentation purposes.
   std::vector<std::string> backgrounds = {"ZTT",  "W",   "ZL",      "ZJ",
                                           "TTT",  "TTJ", "VVT",     "VVJ",
-                                          "EWKZ", "QCD", "jetFakes"};
+                                          "EWKZ", "QCD", "jetFakes", "EMB", "TTL"};
   */
 
   // All processes being taken from simulation
@@ -59,9 +56,8 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding) {
   std::vector<std::string> mc_processes =
       JoinStr({
               signals,
-              {"ZTT", "TTT", "VVT", "EWKZ", "W", "ZJ", "ZL", "TTJ", "VVJ"}
+              {"ZTT", "TTT", "TTL", "VVT", "EWKZ", "W", "ZJ", "ZL", "TTJ", "VVJ"}
               });
-
   // ##########################################################################
   // Uncertainty: Lumi
   // References:
@@ -85,22 +81,22 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding) {
 
   cb.cp()
       .channel({"et"})
-      .process(mc_processes)
+      .process(JoinStr({mc_processes, {"EMB"}}))
       .AddSyst(cb, "CMS_eff_trigger_et_$ERA", "lnN", SystMap<>::init(1.02));
 
   cb.cp()
       .channel({"mt"})
-      .process(mc_processes)
+      .process(JoinStr({mc_processes, {"EMB"}}))
       .AddSyst(cb, "CMS_eff_trigger_mt_$ERA", "lnN", SystMap<>::init(1.02));
 
   cb.cp()
       .channel({"tt"})
-      .process(mc_processes)
+      .process(JoinStr({mc_processes, {"EMB"}}))
       .AddSyst(cb, "CMS_eff_trigger_tt_$ERA", "lnN", SystMap<>::init(1.02));
 
   cb.cp()
       .channel({"em"})
-      .process(mc_processes)
+      .process(JoinStr({mc_processes, {"EMB"}}))
       .AddSyst(cb, "CMS_eff_trigger_em_$ERA", "lnN", SystMap<>::init(1.02));
 
   // ##########################################################################
@@ -115,35 +111,35 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding) {
   // Electron ID
   cb.cp()
       .channel({"et", "em"})
-      .process(mc_processes)
+      .process(JoinStr({mc_processes, {"EMB"}}))
       .AddSyst(cb, "CMS_eff_e_$ERA", "lnN", SystMap<>::init(1.02));
 
   // Muon ID
   cb.cp()
       .channel({"mt", "em"})
-      .process(mc_processes)
+      .process(JoinStr({mc_processes, {"EMB"}}))
       .AddSyst(cb, "CMS_eff_m_$ERA", "lnN", SystMap<>::init(1.02));
 
   // Tau ID: et and mt with 1 real tau
   cb.cp()
       .channel({"et", "mt"})
-      .process(mc_processes)
+      .process(JoinStr({mc_processes, {"EMB"}}))
       .AddSyst(cb, "CMS_eff_t_$ERA", "lnN", SystMap<>::init(1.045));
 
   cb.cp()
       .channel({"et", "mt"})
-      .process(mc_processes)
+      .process(JoinStr({mc_processes, {"EMB"}}))
       .AddSyst(cb, "CMS_eff_t_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.02));
 
   // Tau ID: tt with 2 real taus
   cb.cp()
       .channel({"tt"})
-      .process({"ZTT", "TTT", "VVT", "EWKZ"})
+      .process({"ZTT", "TTT", "VVT", "EWKZ", "EMB"})
       .AddSyst(cb, "CMS_eff_t_$ERA", "lnN", SystMap<>::init(1.09));
 
   cb.cp()
       .channel({"tt"})
-      .process({"ZTT", "TTT", "VVT", "EWKZ"})
+      .process({"ZTT", "TTT", "VVT", "EWKZ", "EMB"})
       .AddSyst(cb, "CMS_eff_t_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.04));
 
   // Tau ID: tt with 1 real taus and 1 jet fake
@@ -183,7 +179,7 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding) {
 
   cb.cp()
       .channel({"em"})
-      .process(mc_processes)
+      .process(JoinStr({mc_processes, {"EMB"}}))
       .AddSyst(cb, "CMS_scale_e_$ERA", "shape", SystMap<>::init(1.00));
 
   // ##########################################################################
@@ -196,18 +192,18 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding) {
 
   cb.cp()
       .channel({"et", "mt", "tt"})
-      .process(JoinStr({signals, {"ZTT", "TTT", "VVT", "EWKZ"}}))
+      .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "EWKZ", "EMB"}}))
       .AddSyst(cb, "CMS_scale_t_1prong_$ERA", "shape", SystMap<>::init(1.00));
 
   cb.cp()
       .channel({"et", "mt", "tt"})
-      .process(JoinStr({signals, {"ZTT", "TTT", "VVT", "EWKZ"}}))
+      .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "EWKZ", "EMB"}}))
       .AddSyst(cb, "CMS_scale_t_1prong1pizero_$ERA", "shape",
                SystMap<>::init(1.00));
 
   cb.cp()
       .channel({"et", "mt", "tt"})
-      .process(JoinStr({signals, {"ZTT", "TTT", "VVT", "EWKZ"}}))
+      .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "EWKZ", "EMB"}}))
       .AddSyst(cb, "CMS_scale_t_3prong_$ERA", "shape", SystMap<>::init(1.00));
 
   // ##########################################################################
@@ -257,7 +253,7 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding) {
   // TT
   cb.cp()
       .channel({"et", "mt", "tt", "em"})
-      .process({"TTT", "TTJ"})
+      .process({"TTT", "TTL", "TTJ"})
       .AddSyst(cb, "CMS_htt_tjXsec_$ERA", "lnN", SystMap<>::init(1.06));
 
   // W
@@ -307,7 +303,7 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding) {
 
   cb.cp()
       .channel({"et", "mt", "tt", "em"})
-      .process({"TTT", "TTJ"})
+      .process({"TTT", "TTL", "TTJ"})
       .AddSyst(cb, "CMS_htt_ttbarShape_$ERA", "shape", SystMap<>::init(1.00));
 
   // ##########################################################################
@@ -421,6 +417,41 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding) {
       .channel({"et", "mt", "tt", "em"})
       .process({"ZH_htt"})
       .AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.016));
+
+  // ##########################################################################
+  // Uncertainty: Embedded events
+  // References:
+  // - https://twiki.cern.ch/twiki/bin/viewauth/CMS/TauTauEmbeddingSamples2016
+  // Notes:
+  // ##########################################################################
+
+  // Embedded Normalization: No Lumi, Zjxsec information used, instead derived from data using dimuon selection efficiency
+  cb.cp()
+      .channel({"et", "mt", "tt", "em"})
+      .process({"EMB"})
+      .AddSyst(cb, "CMS_htt_doublemutrg_$ERA", "lnN", SystMap<>::init(1.04));
+
+  cb.cp()
+      .channel({"tt"})
+      .process({"EMB"})
+      .AddSyst(cb, "CMS_htt_doubletautrg_$ERA", "lnN", SystMap<>::init(1.04));
+      
+  // TTbar contamination in embedded events: 10% shape uncertainty of assumed ttbar->tautau event shape
+  cb.cp()
+    .channel({"et", "mt", "tt", "em"})
+    .process({"EMB"})
+    .AddSyst(cb, "CMS_htt_emb_ttbar_$ERA", "shape", SystMap<>::init(1.00));
+
+  // Uncertainty of hadronic tau track efficiency correction
+  cb.cp()
+    .channel({"et", "mt", "tt", "em"})
+    .process({"EMB"})
+    .AddSyst(cb, "CMS_3ProngEff_$ERA", "shape", SystMap<>::init(1.00));
+
+  cb.cp()
+    .channel({"et", "mt", "tt", "em"})
+    .process({"EMB"})
+    .AddSyst(cb, "CMS_1ProngPi0Eff_$ERA", "shape", SystMap<>::init(1.00));
 
   // ##########################################################################
   // Uncertainty: Jet fakes


### PR DESCRIPTION
Changes:
- Contains the two commits of Stefan's @stwunsch PR https://github.com/cms-analysis/CombineHarvester/pull/169 (so this one could be pulled and the other closed)
- Updated background process selection depending on the "embedding" or "jetfakes" switch
- Included two processes "EMB" = mu->tau embedded events and "TTL" = ttbar-> prompt lepton+tau. This is needed since ttbar->tau tau are included in embedded events, and only ttbar-> prompt lepton+tau need to be determined by MC (so TTL is a subset of TTT)
- Included uncertainties for embedded events (hadronic tau track efficiency, ttbar contamination, normalization)