### PR TITLE
SMHTT2017-dev

### DIFF
--- a/HTTSM2017/bin/MorphingSM2017.cpp
+++ b/HTTSM2017/bin/MorphingSM2017.cpp
@@ -107,24 +107,21 @@ int main(int argc, char **argv) {
   VString bkgs;
   bkgs = {"W", "ZTT", "QCD", "ZL", "ZJ", "TTT", "TTJ", "VVJ", "VVT", "EWKZ"};
   if(embedding){
-      bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "ZTT"), bkgs.end());
-      bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "TTT"), bkgs.end());
-      bkgs = JoinStr({bkgs,{"EMB","TTL"}});
+    bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "ZTT"), bkgs.end());
+    bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "TTT"), bkgs.end());
+    bkgs = JoinStr({bkgs,{"EMB","TTL"}});
   }
   if(jetfakes){
-      bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "QCD"), bkgs.end());
-      bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "W"), bkgs.end());
-      bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "VVJ"), bkgs.end());
-      bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "TTJ"), bkgs.end());
-      bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "ZJ"), bkgs.end());
-      bkgs = JoinStr({bkgs,{"jetFakes"}});
+    bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "QCD"), bkgs.end());
+    bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "W"), bkgs.end());
+    bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "VVJ"), bkgs.end());
+    bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "TTJ"), bkgs.end());
+    bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "ZJ"), bkgs.end());
+    bkgs = JoinStr({bkgs,{"jetFakes"}});
   }
-  
+
   std::cout << "[INFO] Considerung the following processes:\n";
-  for (unsigned int i=0; i < bkgs.size(); i++) {
-  std::cout << bkgs[i] << " ";
-  }
-  std::cout << std::endl;
+  for (unsigned int i=0; i < bkgs.size(); i++) std::cout << bkgs[i] << std::endl;
   bkg_procs["et"] = bkgs;
   bkg_procs["mt"] = bkgs;
   bkg_procs["tt"] = bkgs;

--- a/HTTSM2017/bin/MorphingSM2017.cpp
+++ b/HTTSM2017/bin/MorphingSM2017.cpp
@@ -49,8 +49,9 @@ int main(int argc, char **argv) {
   bool jetfakes = true;
   bool embedding = false;
   bool verbose = false;
-  int stxs_signals = 0; // 0 or 1
-  int stxs_categories = 0; // 0 or 1
+  string stxs_signals = "stxs_stage0"; // "stxs_stage0" or "stxs_stage1"
+  string categories = "stxs_stage0"; // "stxs_stage0", "stxs_stage1" or "gof"
+  string gof_category_name = "gof";
   int era = 2016; // 2016 or 2017
   po::variables_map vm;
   po::options_description config("configuration");
@@ -66,8 +67,9 @@ int main(int argc, char **argv) {
       ("manual_rebin", po::value<bool>(&manual_rebin)->default_value(manual_rebin))
       ("verbose", po::value<bool>(&verbose)->default_value(verbose))
       ("output_folder", po::value<string>(&output_folder)->default_value(output_folder))
-      ("stxs_signals", po::value<int>(&stxs_signals)->default_value(stxs_signals))
-      ("stxs_categories", po::value<int>(&stxs_categories)->default_value(stxs_categories))
+      ("stxs_signals", po::value<string>(&stxs_signals)->default_value(stxs_signals))
+      ("categories", po::value<string>(&categories)->default_value(categories))
+      ("gof_category_name", po::value<string>(&gof_category_name)->default_value(gof_category_name))
       ("jetfakes", po::value<bool>(&jetfakes)->default_value(jetfakes))
       ("embedding", po::value<bool>(&embedding)->default_value(embedding))
       ("era", po::value<int>(&era)->default_value(era));
@@ -132,7 +134,7 @@ int main(int argc, char **argv) {
   // Define categories
   map<string, Categories> cats;
   // STXS stage 0 categories (optimized on ggH and VBF)
-  if(stxs_categories == 0){
+  if(categories == "stxs_stage0"){
     cats["et"] = {
         { 1, "et_ggh"},
         { 2, "et_qqh"},
@@ -165,7 +167,7 @@ int main(int argc, char **argv) {
     };
   }
   // STXS stage 1 categories (optimized on STXS stage 1 splits of ggH and VBF)
-  else if(stxs_categories == 1){
+  else if(categories == "stxs_stage1"){
     cats["et"] = {
         { 1, "et_ggh_unrolled"},
         { 2, "et_qqh_unrolled"},
@@ -197,17 +199,31 @@ int main(int argc, char **argv) {
         // TODO
     };
   }
-  else throw std::runtime_error("Given STXS categories are not known.");
+  else if(categories == "gof"){
+    cats["et"] = {
+        { 100, gof_category_name.c_str() },
+    };
+    cats["mt"] = {
+        { 100, gof_category_name.c_str() },
+    };
+    cats["tt"] = {
+        { 100, gof_category_name.c_str() },
+    };
+    cats["et"] = {
+        // TODO
+    };
+  }
+  else throw std::runtime_error("Given categorization is not known.");
 
   // Specify signal processes and masses
   vector<string> sig_procs;
   // STXS stage 0: ggH and VBF processes
-  if(stxs_signals == 0) sig_procs = {"ggH", "qqH"};
+  if(stxs_signals == "stxs_stage0") sig_procs = {"ggH", "qqH"};
   // STXS stage 1: Splits of ggH and VBF processes
   // References:
   // - https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHXSWGFiducialAndSTXS
   // - https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHXSWG2
-  else if(stxs_signals == 1) sig_procs = {
+  else if(stxs_signals == "stxs_stage1") sig_procs = {
       // ggH
       "ggH_0J", "ggH_1J_PTH_0_60", "ggH_1J_PTH_60_120", "ggH_1J_PTH_120_200",
       "ggH_1J_PTH_GT200", "ggH_GE2J_PTH_0_60", "ggH_GE2J_PTH_60_120",

--- a/HTTSM2017/bin/MorphingSM2017.cpp
+++ b/HTTSM2017/bin/MorphingSM2017.cpp
@@ -49,8 +49,9 @@ int main(int argc, char **argv) {
   bool jetfakes = true;
   bool embedding = false;
   bool verbose = false;
-  int stxs_signals = 0;
-  int stxs_categories = 0;
+  int stxs_signals = 0; // 0 or 1
+  int stxs_categories = 0; // 0 or 1
+  int era = 2016; // 2016 or 2017
   po::variables_map vm;
   po::options_description config("configuration");
   config.add_options()
@@ -68,7 +69,8 @@ int main(int argc, char **argv) {
       ("stxs_signals", po::value<int>(&stxs_signals)->default_value(stxs_signals))
       ("stxs_categories", po::value<int>(&stxs_categories)->default_value(stxs_categories))
       ("jetfakes", po::value<bool>(&jetfakes)->default_value(jetfakes))
-      ("embedding", po::value<bool>(&embedding)->default_value(embedding));
+      ("embedding", po::value<bool>(&embedding)->default_value(embedding))
+      ("era", po::value<int>(&era)->default_value(era));
   po::store(po::command_line_parser(argc, argv).options(config).run(), vm);
   po::notify(vm);
 
@@ -230,7 +232,7 @@ int main(int argc, char **argv) {
   }
 
   // Add systematics
-  ch::AddSMRun2Systematics(cb, jetfakes, embedding);
+  ch::AddSMRun2Systematics(cb, jetfakes, embedding, era);
 
   // Extract shapes from input ROOT files
   for (string chn : chns) {

--- a/HTTSM2017/bin/MorphingSM2017.cpp
+++ b/HTTSM2017/bin/MorphingSM2017.cpp
@@ -37,6 +37,7 @@ int main(int argc, char **argv) {
 
   // Define program options
   string output_folder = "sm_run2";
+  string base_path = string(getenv("CMSSW_BASE")) + "/src/CombineHarvester/HTTSM2017/shapes";
   string input_folder_em = "Vienna/";
   string input_folder_et = "Vienna/";
   string input_folder_mt = "Vienna/";
@@ -58,6 +59,7 @@ int main(int argc, char **argv) {
   po::variables_map vm;
   po::options_description config("configuration");
   config.add_options()
+      ("base_path", po::value<string>(&base_path)->default_value(base_path))
       ("input_folder_em", po::value<string>(&input_folder_em)->default_value(input_folder_em))
       ("input_folder_et", po::value<string>(&input_folder_et)->default_value(input_folder_et))
       ("input_folder_mt", po::value<string>(&input_folder_mt)->default_value(input_folder_mt))
@@ -83,18 +85,10 @@ int main(int argc, char **argv) {
   // Define the location of the "auxiliaries" directory where we can
   // source the input files containing the datacard shapes
   std::map<string, string> input_dir;
-  input_dir["mt"] = string(getenv("CMSSW_BASE")) +
-                    "/src/CombineHarvester/HTTSM2017/shapes/" +
-                    input_folder_mt + "/";
-  input_dir["et"] = string(getenv("CMSSW_BASE")) +
-                    "/src/CombineHarvester/HTTSM2017/shapes/" +
-                    input_folder_et + "/";
-  input_dir["tt"] = string(getenv("CMSSW_BASE")) +
-                    "/src/CombineHarvester/HTTSM2017/shapes/" +
-                    input_folder_tt + "/";
-  input_dir["em"] = string(getenv("CMSSW_BASE")) +
-                    "/src/CombineHarvester/HTTSM2017/shapes/" +
-                    input_folder_em + "/";
+  input_dir["mt"] = base_path + "/" + input_folder_mt + "/";
+  input_dir["et"] = base_path + "/" + input_folder_et + "/";
+  input_dir["tt"] = base_path + "/" + input_folder_tt + "/";
+  input_dir["em"] = base_path + "/" + input_folder_em + "/";
 
   // Define channels
   VString chns;

--- a/HTTSM2017/bin/MorphingSM2017.cpp
+++ b/HTTSM2017/bin/MorphingSM2017.cpp
@@ -43,6 +43,8 @@ int main(int argc, char **argv) {
   string input_folder_tt = "Vienna/";
   string chan = "all";
   string postfix = "-ML";
+  bool regional_jec = true;
+  bool ggh_wg1 = true;
   bool auto_rebin = false;
   bool manual_rebin = false;
   bool real_data = false;
@@ -63,6 +65,8 @@ int main(int argc, char **argv) {
       ("postfix", po::value<string>(&postfix)->default_value(postfix))
       ("channel", po::value<string>(&chan)->default_value(chan))
       ("auto_rebin", po::value<bool>(&auto_rebin)->default_value(auto_rebin))
+      ("regional_jec", po::value<bool>(&regional_jec)->default_value(regional_jec))
+      ("ggh_wg1", po::value<bool>(&ggh_wg1)->default_value(ggh_wg1))
       ("real_data", po::value<bool>(&real_data)->default_value(real_data))
       ("manual_rebin", po::value<bool>(&manual_rebin)->default_value(manual_rebin))
       ("verbose", po::value<bool>(&verbose)->default_value(verbose))
@@ -248,7 +252,7 @@ int main(int argc, char **argv) {
   }
 
   // Add systematics
-  ch::AddSMRun2Systematics(cb, jetfakes, embedding, era);
+  ch::AddSMRun2Systematics(cb, jetfakes, embedding, regional_jec, ggh_wg1, era);
 
   // Extract shapes from input ROOT files
   for (string chn : chns) {

--- a/HTTSM2017/interface/HttSystematics_SMRun2.h
+++ b/HTTSM2017/interface/HttSystematics_SMRun2.h
@@ -5,7 +5,7 @@
 namespace ch {
 // Run2 SM analysis systematics
 // Implemented in src/HttSystematics_SMRun2.cc
-void AddSMRun2Systematics(CombineHarvester& cb, bool jetfakes, bool embedding, int era);
+void AddSMRun2Systematics(CombineHarvester& cb, bool jetfakes, bool embedding, bool regional_jec, bool ggh_wg1, int era);
 }
 
 #endif

--- a/HTTSM2017/interface/HttSystematics_SMRun2.h
+++ b/HTTSM2017/interface/HttSystematics_SMRun2.h
@@ -5,7 +5,7 @@
 namespace ch {
 // Run2 SM analysis systematics
 // Implemented in src/HttSystematics_SMRun2.cc
-void AddSMRun2Systematics(CombineHarvester& cb, bool jetfakes, bool embedding);
+void AddSMRun2Systematics(CombineHarvester& cb, bool jetfakes, bool embedding, int era);
 }
 
 #endif

--- a/HTTSM2017/src/HttSystematics_SMRun2.cc
+++ b/HTTSM2017/src/HttSystematics_SMRun2.cc
@@ -364,10 +364,9 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding) {
   // ##########################################################################
   // Uncertainty: Theory uncertainties
   // References:
-  // - STXS migration uncertainties:
-  //   https://indico.cern.ch/event/682466/contributions/2818245/attachments/1573067/2482834/2017-12-11_STXS.pdf
+  // - Gluon-fusion WG1 uncertainty scheme:
+  //   https://twiki.cern.ch/twiki/bin/view/CMS/HiggsWG/SignalModelingTools
   // Notes:
-  // - FIXME: Add STXS migration uncertainties
   // - FIXME: Add TopMassTreatment from HIG-16043 uncertainty model
   // - FIXME: Compare to HIG-16043 uncertainty model:
   //           - PDF uncertainties splitted by category?
@@ -391,10 +390,12 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding) {
       .AddSyst(cb, "BR_htt_PU_alphas", "lnN", SystMap<>::init(1.0062));
 
   // QCD scale
+  /* Replaced by gluon-fusion WG1 uncertainty scheme
   cb.cp()
       .channel({"et", "mt", "tt", "em"})
       .process(signals_ggH)
       .AddSyst(cb, "QCDScale_ggH", "lnN", SystMap<>::init(1.039));
+  */
   cb.cp()
       .channel({"et", "mt", "tt", "em"})
       .process(signals_qqH)
@@ -418,6 +419,44 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding) {
       .process({"ZH_htt"})
       .AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.016));
 
+  // Gluon-fusion WG1 uncertainty scheme
+  cb.cp()
+    .channel({"et", "mt", "tt", "em"})
+    .process(signals_ggH)
+    .AddSyst(cb, "THU_ggH_Mig01_$ERA", "shape", SystMap<>::init(1.00));
+  cb.cp()
+    .channel({"et", "mt", "tt", "em"})
+    .process(signals_ggH)
+    .AddSyst(cb, "THU_ggH_Mig12_$ERA", "shape", SystMap<>::init(1.00));
+  cb.cp()
+    .channel({"et", "mt", "tt", "em"})
+    .process(signals_ggH)
+    .AddSyst(cb, "THU_ggH_Mu_$ERA", "shape", SystMap<>::init(1.00));
+  cb.cp()
+    .channel({"et", "mt", "tt", "em"})
+    .process(signals_ggH)
+    .AddSyst(cb, "THU_ggH_PT120_$ERA", "shape", SystMap<>::init(1.00));
+  cb.cp()
+    .channel({"et", "mt", "tt", "em"})
+    .process(signals_ggH)
+    .AddSyst(cb, "THU_ggH_PT60_$ERA", "shape", SystMap<>::init(1.00));
+  cb.cp()
+    .channel({"et", "mt", "tt", "em"})
+    .process(signals_ggH)
+    .AddSyst(cb, "THU_ggH_Res_$ERA", "shape", SystMap<>::init(1.00));
+  cb.cp()
+    .channel({"et", "mt", "tt", "em"})
+    .process(signals_ggH)
+    .AddSyst(cb, "THU_ggH_VBF2j_$ERA", "shape", SystMap<>::init(1.00));
+  cb.cp()
+    .channel({"et", "mt", "tt", "em"})
+    .process(signals_ggH)
+    .AddSyst(cb, "THU_ggH_VBF3j_$ERA", "shape", SystMap<>::init(1.00));
+  cb.cp()
+    .channel({"et", "mt", "tt", "em"})
+    .process(signals_ggH)
+    .AddSyst(cb, "THU_ggH_qmtop_$ERA", "shape", SystMap<>::init(1.00));
+
   // ##########################################################################
   // Uncertainty: Embedded events
   // References:
@@ -435,7 +474,7 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding) {
       .channel({"tt"})
       .process({"EMB"})
       .AddSyst(cb, "CMS_htt_doubletautrg_$ERA", "lnN", SystMap<>::init(1.04));
-      
+
   // TTbar contamination in embedded events: 10% shape uncertainty of assumed ttbar->tautau event shape
   cb.cp()
     .channel({"et", "mt", "tt", "em"})

--- a/HTTSM2017/src/HttSystematics_SMRun2.cc
+++ b/HTTSM2017/src/HttSystematics_SMRun2.cc
@@ -209,15 +209,46 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding) {
   // ##########################################################################
   // Uncertainty: Jet energy scale
   // References:
+  // - Talk in CMS Htt meeting by Daniel Winterbottom about regional JES splits:
+  //   https://indico.cern.ch/event/740094/contributions/3055870/
   // Notes:
-  // - Current JES is inclusive. Splitted JES is to be implemented.
-  // - FIXME: References?
   // ##########################################################################
 
+  // Inclusive JES
+  /* Replaced by regional JES splitting
   cb.cp()
       .channel({"et", "mt", "tt"})
       .process(mc_processes)
       .AddSyst(cb, "CMS_scale_j_$ERA", "shape", SystMap<>::init(1.00));
+  */
+
+  // Regional JES
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process(mc_processes)
+      .AddSyst(cb, "CMS_scale_j_eta0to3_$ERA", "shape", SystMap<>::init(1.00));
+
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process(mc_processes)
+      .AddSyst(cb, "CMS_scale_j_eta0to5_$ERA", "shape", SystMap<>::init(1.00));
+
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process(mc_processes)
+      .AddSyst(cb, "CMS_scale_j_eta3to5_$ERA", "shape", SystMap<>::init(1.00));
+
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process(mc_processes)
+      .AddSyst(cb, "CMS_scale_j_RelativeBal_$ERA", "shape", SystMap<>::init(1.00));
+
+  /* Only needed for 2017 data
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process(mc_processes)
+      .AddSyst(cb, "CMS_scale_j_RelativeSample_$ERA", "shape", SystMap<>::init(1.00));
+  */
 
   // ##########################################################################
   // Uncertainty: MET energy scale

--- a/HTTSM2017/src/HttSystematics_SMRun2.cc
+++ b/HTTSM2017/src/HttSystematics_SMRun2.cc
@@ -501,11 +501,6 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding) {
       .process({"EMB"})
       .AddSyst(cb, "CMS_htt_doublemutrg_$ERA", "lnN", SystMap<>::init(1.04));
 
-  cb.cp()
-      .channel({"tt"})
-      .process({"EMB"})
-      .AddSyst(cb, "CMS_htt_doubletautrg_$ERA", "lnN", SystMap<>::init(1.04));
-
   // TTbar contamination in embedded events: 10% shape uncertainty of assumed ttbar->tautau event shape
   cb.cp()
     .channel({"et", "mt", "tt", "em"})

--- a/HTTSM2017/src/HttSystematics_SMRun2.cc
+++ b/HTTSM2017/src/HttSystematics_SMRun2.cc
@@ -18,7 +18,7 @@ using ch::syst::process;
 using ch::syst::bin;
 using ch::JoinStr;
 
-void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, int era) {
+void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, bool regional_jec, bool ggh_wg1, int era) {
 
   // ##########################################################################
   // Define groups of processes
@@ -214,40 +214,41 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, i
   // Notes:
   // ##########################################################################
 
-  // Inclusive JES
-  /* Replaced by regional JES splitting
+  if (!regional_jec) {
   cb.cp()
       .channel({"et", "mt", "tt"})
       .process(mc_processes)
       .AddSyst(cb, "CMS_scale_j_$ERA", "shape", SystMap<>::init(1.00));
-  */
+  }
 
   // Regional JES
-  cb.cp()
-      .channel({"et", "mt", "tt"})
-      .process(mc_processes)
-      .AddSyst(cb, "CMS_scale_j_eta0to3_$ERA", "shape", SystMap<>::init(1.00));
-
-  cb.cp()
-      .channel({"et", "mt", "tt"})
-      .process(mc_processes)
-      .AddSyst(cb, "CMS_scale_j_eta0to5_$ERA", "shape", SystMap<>::init(1.00));
-
-  cb.cp()
-      .channel({"et", "mt", "tt"})
-      .process(mc_processes)
-      .AddSyst(cb, "CMS_scale_j_eta3to5_$ERA", "shape", SystMap<>::init(1.00));
-
-  cb.cp()
-      .channel({"et", "mt", "tt"})
-      .process(mc_processes)
-      .AddSyst(cb, "CMS_scale_j_RelativeBal_$ERA", "shape", SystMap<>::init(1.00));
-
-  if (era == 2017) {
+  else {
     cb.cp()
         .channel({"et", "mt", "tt"})
         .process(mc_processes)
-        .AddSyst(cb, "CMS_scale_j_RelativeSample_$ERA", "shape", SystMap<>::init(1.00));
+        .AddSyst(cb, "CMS_scale_j_eta0to3_$ERA", "shape", SystMap<>::init(1.00));
+
+    cb.cp()
+        .channel({"et", "mt", "tt"})
+        .process(mc_processes)
+        .AddSyst(cb, "CMS_scale_j_eta0to5_$ERA", "shape", SystMap<>::init(1.00));
+
+    cb.cp()
+        .channel({"et", "mt", "tt"})
+        .process(mc_processes)
+        .AddSyst(cb, "CMS_scale_j_eta3to5_$ERA", "shape", SystMap<>::init(1.00));
+
+    cb.cp()
+        .channel({"et", "mt", "tt"})
+        .process(mc_processes)
+        .AddSyst(cb, "CMS_scale_j_RelativeBal_$ERA", "shape", SystMap<>::init(1.00));
+
+    if (era == 2017) {
+      cb.cp()
+          .channel({"et", "mt", "tt"})
+          .process(mc_processes)
+          .AddSyst(cb, "CMS_scale_j_RelativeSample_$ERA", "shape", SystMap<>::init(1.00));
+    }
   }
 
   // ##########################################################################
@@ -421,12 +422,12 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, i
       .AddSyst(cb, "BR_htt_PU_alphas", "lnN", SystMap<>::init(1.0062));
 
   // QCD scale
-  /* Replaced by gluon-fusion WG1 uncertainty scheme
+  if (!ggh_wg1) {
   cb.cp()
       .channel({"et", "mt", "tt", "em"})
       .process(signals_ggH)
       .AddSyst(cb, "QCDScale_ggH", "lnN", SystMap<>::init(1.039));
-  */
+  }
   cb.cp()
       .channel({"et", "mt", "tt", "em"})
       .process(signals_qqH)
@@ -451,42 +452,44 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, i
       .AddSyst(cb, "pdf_Higgs_VH", "lnN", SystMap<>::init(1.016));
 
   // Gluon-fusion WG1 uncertainty scheme
-  cb.cp()
-    .channel({"et", "mt", "tt", "em"})
-    .process(signals_ggH)
-    .AddSyst(cb, "THU_ggH_Mig01_$ERA", "shape", SystMap<>::init(1.00));
-  cb.cp()
-    .channel({"et", "mt", "tt", "em"})
-    .process(signals_ggH)
-    .AddSyst(cb, "THU_ggH_Mig12_$ERA", "shape", SystMap<>::init(1.00));
-  cb.cp()
-    .channel({"et", "mt", "tt", "em"})
-    .process(signals_ggH)
-    .AddSyst(cb, "THU_ggH_Mu_$ERA", "shape", SystMap<>::init(1.00));
-  cb.cp()
-    .channel({"et", "mt", "tt", "em"})
-    .process(signals_ggH)
-    .AddSyst(cb, "THU_ggH_PT120_$ERA", "shape", SystMap<>::init(1.00));
-  cb.cp()
-    .channel({"et", "mt", "tt", "em"})
-    .process(signals_ggH)
-    .AddSyst(cb, "THU_ggH_PT60_$ERA", "shape", SystMap<>::init(1.00));
-  cb.cp()
-    .channel({"et", "mt", "tt", "em"})
-    .process(signals_ggH)
-    .AddSyst(cb, "THU_ggH_Res_$ERA", "shape", SystMap<>::init(1.00));
-  cb.cp()
-    .channel({"et", "mt", "tt", "em"})
-    .process(signals_ggH)
-    .AddSyst(cb, "THU_ggH_VBF2j_$ERA", "shape", SystMap<>::init(1.00));
-  cb.cp()
-    .channel({"et", "mt", "tt", "em"})
-    .process(signals_ggH)
-    .AddSyst(cb, "THU_ggH_VBF3j_$ERA", "shape", SystMap<>::init(1.00));
-  cb.cp()
-    .channel({"et", "mt", "tt", "em"})
-    .process(signals_ggH)
-    .AddSyst(cb, "THU_ggH_qmtop_$ERA", "shape", SystMap<>::init(1.00));
+  if (ggh_wg1) {
+    cb.cp()
+      .channel({"et", "mt", "tt", "em"})
+      .process(signals_ggH)
+      .AddSyst(cb, "THU_ggH_Mig01_$ERA", "shape", SystMap<>::init(1.00));
+    cb.cp()
+      .channel({"et", "mt", "tt", "em"})
+      .process(signals_ggH)
+      .AddSyst(cb, "THU_ggH_Mig12_$ERA", "shape", SystMap<>::init(1.00));
+    cb.cp()
+      .channel({"et", "mt", "tt", "em"})
+      .process(signals_ggH)
+      .AddSyst(cb, "THU_ggH_Mu_$ERA", "shape", SystMap<>::init(1.00));
+    cb.cp()
+      .channel({"et", "mt", "tt", "em"})
+      .process(signals_ggH)
+      .AddSyst(cb, "THU_ggH_PT120_$ERA", "shape", SystMap<>::init(1.00));
+    cb.cp()
+      .channel({"et", "mt", "tt", "em"})
+      .process(signals_ggH)
+      .AddSyst(cb, "THU_ggH_PT60_$ERA", "shape", SystMap<>::init(1.00));
+    cb.cp()
+      .channel({"et", "mt", "tt", "em"})
+      .process(signals_ggH)
+      .AddSyst(cb, "THU_ggH_Res_$ERA", "shape", SystMap<>::init(1.00));
+    cb.cp()
+      .channel({"et", "mt", "tt", "em"})
+      .process(signals_ggH)
+      .AddSyst(cb, "THU_ggH_VBF2j_$ERA", "shape", SystMap<>::init(1.00));
+    cb.cp()
+      .channel({"et", "mt", "tt", "em"})
+      .process(signals_ggH)
+      .AddSyst(cb, "THU_ggH_VBF3j_$ERA", "shape", SystMap<>::init(1.00));
+    cb.cp()
+      .channel({"et", "mt", "tt", "em"})
+      .process(signals_ggH)
+      .AddSyst(cb, "THU_ggH_qmtop_$ERA", "shape", SystMap<>::init(1.00));
+  }
 
   // ##########################################################################
   // Uncertainty: Embedded events

--- a/HTTSM2017/src/HttSystematics_SMRun2.cc
+++ b/HTTSM2017/src/HttSystematics_SMRun2.cc
@@ -18,7 +18,7 @@ using ch::syst::process;
 using ch::syst::bin;
 using ch::JoinStr;
 
-void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding) {
+void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, int era) {
 
   // ##########################################################################
   // Define groups of processes
@@ -243,12 +243,12 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding) {
       .process(mc_processes)
       .AddSyst(cb, "CMS_scale_j_RelativeBal_$ERA", "shape", SystMap<>::init(1.00));
 
-  /* Only needed for 2017 data
-  cb.cp()
-      .channel({"et", "mt", "tt"})
-      .process(mc_processes)
-      .AddSyst(cb, "CMS_scale_j_RelativeSample_$ERA", "shape", SystMap<>::init(1.00));
-  */
+  if (era == 2017) {
+    cb.cp()
+        .channel({"et", "mt", "tt"})
+        .process(mc_processes)
+        .AddSyst(cb, "CMS_scale_j_RelativeSample_$ERA", "shape", SystMap<>::init(1.00));
+  }
 
   // ##########################################################################
   // Uncertainty: MET energy scale


### PR DESCRIPTION
Changes:
1. Regional JEC splitting for 2016 and 2017
2. Gluon-fusion WG1 uncertainty scheme
3. Switch for 2016/2017 datacards, e.g., JEC uncertainty only for 2017
4. Refined embedding uncertainty model
5. Add option to create datacard for single category, to be used for inclusive goodness of fit tests
6. Add option to toggle regional JEC and ggH WG1 uncertainty scheme (default: enabled)
7. Add option to set base path for input datacards, default behaves as before (selects folder based on CMSSW_BASE)