### PR TITLE
Document asymmetric uncertainties

### DIFF
--- a/docs/Example2.md
+++ b/docs/Example2.md
@@ -55,6 +55,8 @@ So in this example we will expect names like "lumi_8TeV". This substitution prov
 
 \snippet CombineTools/bin/Example2.cpp part6
 
+Creation of asymmetric "lnN" uncertainties is supported through the [SystMapAsymm](\ref ch::syst::SystMapAsymm) class, whose interface is very similar to [SystMap](\ref ch::syst::SystMap). Instead of a single uncertainty value, simply provide the "down" and "up" relative uncertainties as two separate arguments.
+
 Extracting shape inputs {#ex2-p3}
 =================================
 Next we populate these Observation, Process and Systematic entries with the actual histograms (and also yields). The last two arguments are the patterns which will be used to determine the paths of the nominal and systematic shape templates in the given file. Here we must do this separately for signal and background shapes which use a different naming convention. NOTE: In this method only the following substitutions are supported:

--- a/docs/PythonInterface.md
+++ b/docs/PythonInterface.md
@@ -249,6 +249,19 @@ Python:
         (['et'], ['8TeV'],          [1, 2],               1.010)
         (['et'], ['8TeV'],          [3, 5, 6, 7],         1.040))
 
+Note that asymmetric uncertainties are created in a different way in Python or C++:
+
+C++:
+
+    cb.cp().process({"WH", "ZH"}).AddSyst(
+      cb, "QCDscale_VH", "lnN", SystMapAsymm<channel, era, bin_id>::init
+        ({"mt"}, {"7TeV", "8TeV"}, {1, 2}, 0.91, 1.05));
+
+Python:
+
+    cb.cp().process(['WH', 'ZH']).AddSyst(
+      cb, "QCDscale_VH", "lnN", ch.SystMap('channel', 'era', 'bin_id')
+        (['mt'], ['7TeV', '8TeV'], [1, 2], (0.91, 1.05)))
 
 The ExtractPdfs, ExtractData and AddWorkspace methods are not currently supported.
 


### PR DESCRIPTION
Minimal documentation of the creating of asymmetric lnN uncertainties in C++ and Python, which currently does not seem to be referenced anywhere.