### PR TITLE
[SMHTT2017-dev] Merge changes from KIT

### DIFF
--- a/HTTSM2017/Protocol_SM_Htt_2017.md
+++ b/HTTSM2017/Protocol_SM_Htt_2017.md
@@ -1,46 +1,143 @@
-# THIS NEEDS FURTHER UPDATES - work-in-progress
-
 # Links
 [CombineHarvester twiki](http://cms-analysis.github.io/CombineHarvester/index.html)
 [Combine gitbook](https://cms-hcomb.gitbooks.io/combine/content/)
 
 # Creating datacards
 
-    MorphingSM2017 --input_folder_mt=Vienna/ --input_folder_et=Vienna/ --input_folder_tt=Vienna/ --input_folder_em=Vienna/ --input_folder_mm=Vienna/ --input_folder_ttbar=Vienna/  --channel="mt" --jetfakes=true --postfix="-ML" --auto_rebin=true --real_data=false --output_folder test &>log_dc.txt
-    MorphingSM2017 --input_folder_mt=Vienna/ --channel="mt" --jetfakes=true --postfix="-ML" --auto_rebin=true --real_data=false --output_folder test &>log_dc.txt   #same for just one channel
-    MorphingSM2017 --input_folder_mt=Vienna/ --input_folder_et=Vienna/ --channel="mt,et" --jetfakes=true --postfix="-ML" --auto_rebin=true --real_data=false --output_folder test &>log_dc.txt   #same for a few channels
+```bash
+$CMSSW_BASE/bin/slc6_amd64_gcc491/MorphingSM2017 \
+    --base_path=$BASE_PATH \        # Base path for finding ROOT files with shapes
+    --input_folder_mt="/mt/" \      # Path relative to base_path containing the
+                                    # mt shapes
+    --input_folder_et="/et/" \      # Path relative to base_path containing the
+                                    # et shapes
+    --input_folder_tt="/tt/" \      # Path relative to base_path containing the
+                                    # tt shapes
+    --real_data=false \             # Fit with real data or Asimov data
+    --jetfakes=$JETFAKES \          # Toggle usage of fake-factor method
+    --embedding=$EMBEDDING \        # Toggle usage of embedded samples
+    --postfix="-ML" \               # Expected postfix for the input ROOT files
+                                    # with the shapes
+    --channel="${CHANNELS}" \       # Analysis channels: Any combination of "em",
+                                    # "et", "mt" and "tt" as single string
+    --auto_rebin=true \             # Enable automatic rebinning
+    --stxs_signals=$STXS_SIGNALS \  # Signal templates: "stxs_stage0" for ggH and qqH
+                                    # or "stxs_stag1" for the stage 1 splitting
+    --categories=$CATEGORIES \      # Categorization optimized for STXS stages:
+                                    # "stxs_stage0" or "stxs_stage1"
+    --era=$ERA \                    # Data-taking era: 2016 or 2017
+    --output="${ERA}_smhtt"         # name of subdirectory in output directory
+```
 
 
-# Building the workspaces:
+# Building the workspaces
 
-    cd output/test
-    combineTool.py -M T2W -i {cmb,em,et,mt,tt}/* -o workspace.root --parallel 8 &>log_ws.txt   #remove directories within curly brackets as desired
+## Inclusive signal
 
+```bash
+ERA=2016
+DATACARD_PATH=output/${ERA}_smhtt/cmb/125
+NUM_THREADS=12
+combineTool.py -M T2W -o ${ERA}_workspace.root -i ${DATACARD_PATH} --parallel $NUM_THREADS
+```
 
-# Calculating limits and significances:
-    combineTool.py -M Asymptotic -d */*/workspace.root --there -n .limit -t -1 --parallel 8
-    combine -M ProfileLikelihood --significance cmb/125/workspace.root -t -1 --expectSignal=1   #a-priori Asimov
-    combine -M ProfileLikelihood --significance cmb/125/workspace.root -t -1 --toysFrequentist --expectSignal 1 #a-posteriori Asimov
+## STXS stage 0 signals
 
+```bash
+ERA=2016
+DATACARD_PATH=output/${ERA}_smhtt/cmb/125
+NUM_THREADS=12
+combineTool.py -M T2W -o ${ERA}_workspace.root -i ${DATACARD_PATH} --parallel $NUM_THREADS \
+    -P HiggsAnalysis.CombinedLimit.PhysicsModel:multiSignalModel \
+    --PO '"map=^.*/ggH.?$:r_ggH[1,-5,5]"' \
+    --PO '"map=^.*/qqH.?$:r_qqH[1,-5,5]"'
+```
 
-# run MaxLikelihoodFit
+## STXS stage 1 signals
 
-    combine -M MaxLikelihoodFit cmb/125/workspace.root --robustFit=1 -m 125 --minimizerAlgoForMinos=Minuit2,Migrad  --rMin 0.3 --rMax 2.0 --name ".res"
-    
+```bash
+ERA=2016
+DATACARD_PATH=output/${ERA}_smhtt/cmb/125
+NUM_THREADS=12
+combineTool.py -M T2W -o ${ERA}_workspace.root -i ${DATACARD_PATH} --parallel $NUM_THREADS \
+    -P HiggsAnalysis.CombinedLimit.PhysicsModel:multiSignalModel \
+    --PO '"map=^.*/ggH_0J.?$:r_ggH_0J[1,-30,30]"' \
+    --PO '"map=^.*/ggH_1J_PTH_0_60.?$:r_ggH_1J_PTH_0_60[1,-30,30]"' \
+    --PO '"map=^.*/ggH_1J_PTH_60_120.?$:r_ggH_1J_PTH_60_120[1,-30,30]"' \
+    --PO '"map=^.*/ggH_1J_PTH_120_200.?$:r_ggH_1J_PTH_120_200[1,-30,30]"' \
+    --PO '"map=^.*/ggH_1J_PTH_GT200.?$:r_ggH_1J_PTH_GT200[1,-30,30]"' \
+    --PO '"map=^.*/ggH_GE2J_PTH_0_60.?$:r_ggH_GE2J_PTH_0_60[1,-30,30]"' \
+    --PO '"map=^.*/ggH_GE2J_PTH_60_120.?$:r_ggH_GE2J_PTH_60_120[1,-30,30]"' \
+    --PO '"map=^.*/ggH_GE2J_PTH_120_200.?$:r_ggH_GE2J_PTH_120_200[1,-30,30]"' \
+    --PO '"map=^.*/ggH_GE2J_PTH_GT200.?$:r_ggH_GE2J_PTH_GT200[1,-30,30]"' \
+    --PO '"map=^.*/ggH_VBFTOPO_JET3.?$:r_ggH_VBFTOPO_JET3[1,-30,30]"' \
+    --PO '"map=^.*/ggH_VBFTOPO_JET3VETO.?$:r_ggH_VBFTOPO_JET3VETO[1,-30,30]"' \
+    --PO '"map=^.*/qqH_VBFTOPO_JET3VETO.?$:r_qqH_VBFTOPO_JET3VETO[1,-30,30]"' \
+    --PO '"map=^.*/qqH_VBFTOPO_JET3.?$:r_qqH_VBFTOPO_JET3[1,-30,30]"' \
+    --PO '"map=^.*/qqH_REST.?$:r_qqH_REST[1,-30,30]"' \
+    --PO '"map=^.*/qqH_VH2JET.?$:r_qqH_VH2JET[1,-100,100]"' \
+    --PO '"map=^.*/qqH_PTJET1_GT200.?$:r_qqH_PTJET1_GT200[1,-30,30]"'
+```
 
-# making the pulls
+# Calculating signal strength constraints
 
-    python ../../../../../HiggsAnalysis/CombinedLimit/test/diffNuisances.py  mlfit.root -A -a --stol 0.99 --stol 0.99 --vtol 99. --vtol2 99. -f text mlfit.root > mlfit.txt
+## Inclusive signal
 
+```bash
+ERA=2016
+combine -M MaxLikelihoodFit -m 125 ${ERA}_workspace.root \
+    --robustFit 1 -n $ERA \
+    --minimizerAlgoForMinos=Minuit2,Migrad
+```
 
-# postfit plots
+## STXS stage 0 and stage 1 signals
 
-    PostFitShapes -o postfit_shapes.root -m 125 -f mlfit.root:fit_s --postfit --sampling --print -d cmb/125/combined.txt.cmb
-    
+```bash
+ERA=2016
+combineTool.py -M MultiDimFit -m 125 -d ${ERA}_workspace.root \
+    --algo singles -t -1 --expectSignal 1 \
+    --X-rtd FITTER_NEW_CROSSING_ALGO --X-rtd FITTER_NEVER_GIVE_UP \
+    --robustFit 1 -n $ERA \
+    --minimizerAlgoForMinos=Minuit2,Migrad
+```
 
-# Computing the Impact (blinded)
+# Pulls and nuisance impacts
 
-    combineTool.py -M Impacts -d cmb/125/workspace.root -m 125 --doInitialFit --robustFit 1 -t -1 --rMin 0.5 --rMax 1.5 --expectSignal=1 --parallel 8
-    combineTool.py -M Impacts -d cmb/125/workspace.root -m 125 --robustFit 1 --doFits -t -1 --rMin 0.5 --rMax 1.5 --expectSignal=1 --parallel 8 --X-rtd FITTER_NEW_CROSSING_ALGO --X-rtd FITTER_NEVER_GIVE_UP
-    combineTool.py -M Impacts -d cmb/125/workspace.root -m 125 -o impacts.json
-    plotImpacts.py -i impacts.json -o impacts
+## Pulls
+
+```bash
+ERA=2016
+# This puts the pulls in an HTML page. The option -f text puts the results in a text file.
+# The file mlfit${ERA}.root is the result of the MaxLikelihoodFit above.
+python $CMSSW_BASE/src/HiggsAnalysis/CombinedLimit/test/diffNuisances.py -a \
+    -f html mlfit${ERA}.root > ${ERA}_diff_nuisances.html
+```
+
+## Nuisance impacts
+
+```bash
+ERA=2016
+combineTool.py -M Impacts -m 125 -d ${ERA}_workspace.root --doInitialFit \
+    --robustFit 1 -t -1 --expectSignal=1 --parallel 20 --minimizerAlgoForMinos=Minuit2,Migrad
+combineTool.py -M Impacts -m 125 -d ${ERA}_workspace.root --doFits \
+    --parallel 20 --robustFit 1 -t -1 --expectSignal=1 --minimizerAlgoForMinos=Minuit2,Migrad
+combineTool.py -M Impacts -m 125 -d ${ERA}_workspace.root --output ${ERA}_impacts.json
+plotImpacts.py -i ${ERA}_impacts.json -o ${ERA}_impacts
+```
+
+# Prefit and postfit shapes for plotting
+
+```bash
+# Prefit shapes
+# The text datacard is referenced only to add the original binning of the shapes
+# to the output histograms of the command. Otherwise, the bins are numbered with
+# integers.
+PostFitShapesFromWorkspace -m 125 -w ${ERA}_workspace.root \
+    -d output/${ERA}_smhtt/cmb/125/combined.txt.cmb -o ${ERA}_datacard_shapes_prefit.root
+
+# Postfit shapes
+# The file mlfit${ERA}.root is the result of the MaxLikelihoodFit above
+PostFitShapesFromWorkspace -m 125 -w ${ERA}_workspace.root \
+    -d output/${ERA}_smhtt/cmb/125/combined.txt.cmb -o ${ERA}_datacard_shapes_postfit_sb.root \
+    -f mlfit${ERA}.root:fit_s --postfit
+```

--- a/HTTSM2017/bin/MorphingSM2017.cpp
+++ b/HTTSM2017/bin/MorphingSM2017.cpp
@@ -107,10 +107,11 @@ int main(int argc, char **argv) {
   // Define background processes
   map<string, VString> bkg_procs;
   VString bkgs;
-  bkgs = {"W", "ZTT", "QCD", "ZL", "ZJ", "TTT", "TTJ", "VVJ", "VVT", "EWKZ"};
+  bkgs = {"W", "ZTT", "QCD", "ZL", "ZJ", "TTT", "TTJ", "VVJ", "VVT", "EWKL", "EWKJ", "EWKT"};
   if(embedding){
     bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "ZTT"), bkgs.end());
     bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "TTT"), bkgs.end());
+    bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "EWKT"), bkgs.end());
     bkgs = JoinStr({bkgs,{"EMB","TTL"}});
   }
   if(jetfakes){
@@ -119,6 +120,7 @@ int main(int argc, char **argv) {
     bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "VVJ"), bkgs.end());
     bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "TTJ"), bkgs.end());
     bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "ZJ"), bkgs.end());
+    bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "EWKJ"), bkgs.end());
     bkgs = JoinStr({bkgs,{"jetFakes"}});
   }
 

--- a/HTTSM2017/bin/MorphingSM2017.cpp
+++ b/HTTSM2017/bin/MorphingSM2017.cpp
@@ -107,11 +107,12 @@ int main(int argc, char **argv) {
   // Define background processes
   map<string, VString> bkg_procs;
   VString bkgs;
-  bkgs = {"W", "ZTT", "QCD", "ZL", "ZJ", "TTT", "TTJ", "VVJ", "VVT"};
+  bkgs = {"W", "ZTT", "QCD", "ZL", "ZJ", "TTT", "TTL", "TTJ", "VVJ", "VVT", "VVL"};
   if(embedding){
     bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "ZTT"), bkgs.end());
     bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "TTT"), bkgs.end());
-    bkgs = JoinStr({bkgs,{"EMB","TTL"}});
+    bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "VVT"), bkgs.end());
+    bkgs = JoinStr({bkgs,{"EMB"}});
   }
   if(jetfakes){
     bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "QCD"), bkgs.end());

--- a/HTTSM2017/bin/MorphingSM2017.cpp
+++ b/HTTSM2017/bin/MorphingSM2017.cpp
@@ -107,11 +107,10 @@ int main(int argc, char **argv) {
   // Define background processes
   map<string, VString> bkg_procs;
   VString bkgs;
-  bkgs = {"W", "ZTT", "QCD", "ZL", "ZJ", "TTT", "TTJ", "VVJ", "VVT", "EWKL", "EWKJ", "EWKT"};
+  bkgs = {"W", "ZTT", "QCD", "ZL", "ZJ", "TTT", "TTJ", "VVJ", "VVT"};
   if(embedding){
     bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "ZTT"), bkgs.end());
     bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "TTT"), bkgs.end());
-    bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "EWKT"), bkgs.end());
     bkgs = JoinStr({bkgs,{"EMB","TTL"}});
   }
   if(jetfakes){
@@ -120,7 +119,6 @@ int main(int argc, char **argv) {
     bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "VVJ"), bkgs.end());
     bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "TTJ"), bkgs.end());
     bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "ZJ"), bkgs.end());
-    bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "EWKJ"), bkgs.end());
     bkgs = JoinStr({bkgs,{"jetFakes"}});
   }
 

--- a/HTTSM2017/bin/MorphingSM2017.cpp
+++ b/HTTSM2017/bin/MorphingSM2017.cpp
@@ -208,7 +208,7 @@ int main(int argc, char **argv) {
     cats["tt"] = {
         { 100, gof_category_name.c_str() },
     };
-    cats["et"] = {
+    cats["em"] = {
         // TODO
     };
   }

--- a/HTTSM2017/bin/MorphingSM2017.cpp
+++ b/HTTSM2017/bin/MorphingSM2017.cpp
@@ -106,13 +106,16 @@ int main(int argc, char **argv) {
 
   // Define background processes
   map<string, VString> bkg_procs;
-  VString bkgs;
+  VString bkgs, bkgs_em;
   bkgs = {"W", "ZTT", "QCD", "ZL", "ZJ", "TTT", "TTL", "TTJ", "VVJ", "VVT", "VVL"};
+  bkgs_em = {"W", "ZTT", "QCD", "ZL", "TT", "VV", "ST"};
   if(embedding){
     bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "ZTT"), bkgs.end());
     bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "TTT"), bkgs.end());
     bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "VVT"), bkgs.end());
     bkgs = JoinStr({bkgs,{"EMB"}});
+    bkgs_em.erase(std::remove(bkgs_em.begin(), bkgs_em.end(), "ZTT"), bkgs_em.end());
+    bkgs_em = JoinStr({bkgs_em,{"EMB"}});
   }
   if(jetfakes){
     bkgs.erase(std::remove(bkgs.begin(), bkgs.end(), "QCD"), bkgs.end());
@@ -124,11 +127,18 @@ int main(int argc, char **argv) {
   }
 
   std::cout << "[INFO] Considerung the following processes:\n";
-  for (unsigned int i=0; i < bkgs.size(); i++) std::cout << bkgs[i] << std::endl;
+  if (chan.find("em") != std::string::npos) {
+    std::cout << "For em channel : \n";
+    for (unsigned int i=0; i < bkgs_em.size(); i++) std::cout << bkgs_em[i] << std::endl;
+  }
+  if (chan.find("mt") != std::string::npos || chan.find("et") != std::string::npos || chan.find("tt") != std::string::npos) {
+    std::cout << "For et,mt,tt channels : \n";
+    for (unsigned int i=0; i < bkgs.size(); i++) std::cout << bkgs[i] << std::endl;
+  }
   bkg_procs["et"] = bkgs;
   bkg_procs["mt"] = bkgs;
   bkg_procs["tt"] = bkgs;
-  bkg_procs["em"] = bkgs;
+  bkg_procs["em"] = bkgs_em;
 
   // Define categories
   map<string, Categories> cats;
@@ -162,7 +172,14 @@ int main(int argc, char **argv) {
         {17, "tt_noniso"},
     };
      cats["em"] = {
-        // TODO
+        { 1, "em_ggh"},
+        { 2, "em_qqh"},
+        {12, "em_ztt"},
+        {13, "em_tt"},
+        {14, "em_ss"},
+        {16, "em_misc"},
+        {18, "em_st"},
+        {19, "em_vv"},
     };
   }
   // STXS stage 1 categories (optimized on STXS stage 1 splits of ggH and VBF)
@@ -195,7 +212,14 @@ int main(int argc, char **argv) {
         {17, "tt_noniso"},
     };
      cats["em"] = {
-        // TODO
+        { 1, "em_ggh_unrolled"},
+        { 2, "em_qqh_unrolled"},
+        {12, "em_ztt"},
+        {13, "em_tt"},
+        {14, "em_ss"},
+        {16, "em_misc"},
+        {18, "em_st"},
+        {19, "em_vv"},
     };
   }
   else if(categories == "gof"){
@@ -209,7 +233,7 @@ int main(int argc, char **argv) {
         { 100, gof_category_name.c_str() },
     };
     cats["em"] = {
-        // TODO
+        { 100, gof_category_name.c_str() },
     };
   }
   else throw std::runtime_error("Given categorization is not known.");

--- a/HTTSM2017/src/HttSystematics_SMRun2.cc
+++ b/HTTSM2017/src/HttSystematics_SMRun2.cc
@@ -56,7 +56,7 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
   std::vector<std::string> mc_processes =
       JoinStr({
               signals,
-              {"ZTT", "TTT", "TTL", "VVT", "EWKZ", "W", "ZJ", "ZL", "TTJ", "VVJ"}
+              {"ZTT", "TTT", "TTL", "VVT", "EWKL", "EWKT", "EWKJ", "W", "ZJ", "ZL", "TTJ", "VVJ"}
               });
   // ##########################################################################
   // Uncertainty: Lumi
@@ -155,23 +155,23 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
   // Tau ID: tt with 2 real taus
   cb.cp()
       .channel({"tt"})
-      .process({"ZTT", "TTT", "VVT", "EWKZ", "EMB"})
+      .process({"ZTT", "TTT", "VVT", "EWKT", "EMB"})
       .AddSyst(cb, "CMS_eff_t_$ERA", "lnN", SystMap<>::init(1.09));
 
   cb.cp()
       .channel({"tt"})
-      .process({"ZTT", "TTT", "VVT", "EWKZ", "EMB"})
+      .process({"ZTT", "TTT", "VVT", "EWKT", "EMB"})
       .AddSyst(cb, "CMS_eff_t_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.04));
 
   // Tau ID: tt with 1 real taus and 1 jet fake
   cb.cp()
       .channel({"tt"})
-      .process({"W", "ZJ", "ZL", "TTJ", "VVJ"})
+      .process({"W", "ZJ", "TTJ", "VVJ", "EWKJ"})
       .AddSyst(cb, "CMS_eff_t_$ERA", "lnN", SystMap<>::init(1.06));
 
   cb.cp()
       .channel({"tt"})
-      .process({"W", "ZJ", "ZL", "TTJ", "VVJ"})
+      .process({"W", "ZJ", "TTJ", "VVJ", "EWKJ"})
       .AddSyst(cb, "CMS_eff_t_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.02));
 
   // ##########################################################################
@@ -213,18 +213,18 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
 
   cb.cp()
       .channel({"et", "mt", "tt"})
-      .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "EWKZ", "EMB"}}))
+      .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "VVL", "EWKT", "EMB"}}))
       .AddSyst(cb, "CMS_scale_t_1prong_$ERA", "shape", SystMap<>::init(1.00));
 
   cb.cp()
       .channel({"et", "mt", "tt"})
-      .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "EWKZ", "EMB"}}))
+      .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "VVL", "EWKT", "EMB"}}))
       .AddSyst(cb, "CMS_scale_t_1prong1pizero_$ERA", "shape",
                SystMap<>::init(1.00));
 
   cb.cp()
       .channel({"et", "mt", "tt"})
-      .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "EWKZ", "EMB"}}))
+      .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "VVL", "EWKT", "EMB"}}))
       .AddSyst(cb, "CMS_scale_t_3prong_$ERA", "shape", SystMap<>::init(1.00));
 
   // ##########################################################################
@@ -382,23 +382,23 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
   // Electron fakes
   cb.cp()
       .channel({"et"})
-      .process({"ZL"})
+      .process({"ZL", "EWKL"})
       .AddSyst(cb, "CMS_eFakeTau_1prong_$ERA", "shape", SystMap<>::init(1.00));
 
   cb.cp()
       .channel({"et"})
-      .process({"ZL"})
+      .process({"ZL", "EWKL"})
       .AddSyst(cb, "CMS_eFakeTau_1prong1pizero_$ERA", "shape", SystMap<>::init(1.00));
 
   // Muon fakes
   cb.cp()
       .channel({"mt"})
-      .process({"ZL"})
+      .process({"ZL", "EWKL"})
       .AddSyst(cb, "CMS_mFakeTau_1prong_$ERA", "shape", SystMap<>::init(1.00));
 
   cb.cp()
       .channel({"mt"})
-      .process({"ZL"})
+      .process({"ZL", "EWKL"})
       .AddSyst(cb, "CMS_mFakeTau_1prong1pizero_$ERA", "shape", SystMap<>::init(1.00));
 
   // ##########################################################################
@@ -411,7 +411,7 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
 
   cb.cp()
       .channel({"et", "mt", "tt"})
-      .process({"W", "TTJ", "ZJ", "VVJ"})
+      .process({"W", "TTJ", "ZJ", "VVJ", "EWKJ"})
       .AddSyst(cb, "CMS_htt_jetToTauFake_$ERA", "shape", SystMap<>::init(1.00));
 
   // ##########################################################################

--- a/HTTSM2017/src/HttSystematics_SMRun2.cc
+++ b/HTTSM2017/src/HttSystematics_SMRun2.cc
@@ -384,12 +384,7 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
       cb.cp()
           .channel({"et"})
           .process({"ZL"})
-          .AddSyst(cb, "CMS_eFakeTau_1prong_$ERA", "shape", SystMap<>::init(1.00));
-
-      cb.cp()
-          .channel({"et"})
-          .process({"ZL"})
-          .AddSyst(cb, "CMS_eFakeTau_1prong1pizero_$ERA", "shape", SystMap<>::init(1.00));
+          .AddSyst(cb, "CMS_eFakeTau_$ERA", "lnN", SystMap<>::init(1.155));
   }else if (era == 2017) {
       cb.cp()
           .channel({"et"})
@@ -402,12 +397,7 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
       cb.cp()
           .channel({"mt"})
           .process({"ZL"})
-          .AddSyst(cb, "CMS_mFakeTau_1prong_$ERA", "shape", SystMap<>::init(1.00));
-
-      cb.cp()
-          .channel({"mt"})
-          .process({"ZL"})
-          .AddSyst(cb, "CMS_mFakeTau_1prong1pizero_$ERA", "shape", SystMap<>::init(1.00));
+          .AddSyst(cb, "CMS_mFakeTau_$ERA", "lnN", SystMap<>::init(1.272));
   }else if (era == 2017) {
       cb.cp()
           .channel({"mt"})

--- a/HTTSM2017/src/HttSystematics_SMRun2.cc
+++ b/HTTSM2017/src/HttSystematics_SMRun2.cc
@@ -105,7 +105,7 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
       .process(mc_processes)
       .AddSyst(cb, "CMS_eff_trigger_em_$ERA", "lnN", SystMap<>::init(1.02));
 
-  // should be de-correlated for embedded
+  // 100% uncorrelated for embedded
   cb.cp()
       .channel({"et"})
       .process({"EMB"})
@@ -135,78 +135,43 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
   // - FIXME: References?
   // ##########################################################################
 
+  // MC uncorrelated uncertainty
+  
   // Electron ID
   cb.cp()
       .channel({"et", "em"})
       .process(mc_processes)
-      .AddSyst(cb, "CMS_eff_e_$ERA", "lnN", SystMap<>::init(1.02));
+      .AddSyst(cb, "CMS_eff_mc_e_$ERA", "lnN", SystMap<>::init(1.014));
 
   // Muon ID
   cb.cp()
       .channel({"mt", "em"})
       .process(mc_processes)
-      .AddSyst(cb, "CMS_eff_m_$ERA", "lnN", SystMap<>::init(1.02));
+      .AddSyst(cb, "CMS_eff_mc_m_$ERA", "lnN", SystMap<>::init(1.014));
 
   // Tau ID: et and mt with 1 real tau
   cb.cp()
       .channel({"et", "mt"})
       .process(mc_processes)
-      .AddSyst(cb, "CMS_eff_t_$ERA", "lnN", SystMap<>::init(1.045));
+      .AddSyst(cb, "CMS_eff_mc_t_$ERA", "lnN", SystMap<>::init(1.032));
 
   cb.cp()
       .channel({"et", "mt"})
       .process(mc_processes)
-      .AddSyst(cb, "CMS_eff_t_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.02));
+      .AddSyst(cb, "CMS_eff_mc_t_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.014));
 
   // Tau ID: tt with 2 real taus
   cb.cp()
       .channel({"tt"})
-      .process({"ZTT", "TTT", "VVT"})
-      .AddSyst(cb, "CMS_eff_t_$ERA", "lnN", SystMap<>::init(1.09));
+      .process(mc_processes)
+      .AddSyst(cb, "CMS_eff_mc_t_$ERA", "lnN", SystMap<>::init(1.064));
 
   cb.cp()
       .channel({"tt"})
-      .process({"ZTT", "TTT", "VVT"})
-      .AddSyst(cb, "CMS_eff_t_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.04));
+      .process(mc_processes)
+      .AddSyst(cb, "CMS_eff_mc_t_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.028));
 
-  // 50% correlation for embedded
-  // correlated part
-
-  // Electron ID
-  cb.cp()
-      .channel({"et", "em"})
-      .process({"EMB"})
-      .AddSyst(cb, "CMS_eff_e_$ERA", "lnN", SystMap<>::init(1.014));
-
-  // Muon ID
-  cb.cp()
-      .channel({"mt", "em"})
-      .process({"EMB"})
-      .AddSyst(cb, "CMS_eff_m_$ERA", "lnN", SystMap<>::init(1.014));
-
-  // Tau ID: et and mt with 1 real tau
-  cb.cp()
-      .channel({"et", "mt"})
-      .process({"EMB"})
-      .AddSyst(cb, "CMS_eff_t_$ERA", "lnN", SystMap<>::init(1.032));
-
-  cb.cp()
-      .channel({"et", "mt"})
-      .process({"EMB"})
-      .AddSyst(cb, "CMS_eff_t_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.014));
-
-  // Tau ID: tt with 2 real taus
-  cb.cp()
-      .channel({"tt"})
-      .process({"EMB"})
-      .AddSyst(cb, "CMS_eff_t_$ERA", "lnN", SystMap<>::init(1.064));
-
-  cb.cp()
-      .channel({"tt"})
-      .process({"EMB"})
-      .AddSyst(cb, "CMS_eff_t_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.028));
-
-  // uncorrelated part
+  // Embedded uncorrelated uncertainty
 
   // Electron ID
   cb.cp()
@@ -243,6 +208,42 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
       .AddSyst(cb, "CMS_eff_emb_t_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.028));
 
 
+  // MC + embedded correlated uncertainty
+
+  // Electron ID
+  cb.cp()
+      .channel({"et", "em"})
+      .process(JoinStr({mc_processes, {"EMB"}}))
+      .AddSyst(cb, "CMS_eff_e_$ERA", "lnN", SystMap<>::init(1.014));
+
+  // Muon ID
+  cb.cp()
+      .channel({"mt", "em"})
+      .process(JoinStr({mc_processes, {"EMB"}}))
+      .AddSyst(cb, "CMS_eff_m_$ERA", "lnN", SystMap<>::init(1.014));
+
+  // Tau ID: et and mt with 1 real tau
+  cb.cp()
+      .channel({"et", "mt"})
+      .process(JoinStr({mc_processes, {"EMB"}}))
+      .AddSyst(cb, "CMS_eff_t_$ERA", "lnN", SystMap<>::init(1.032));
+
+  cb.cp()
+      .channel({"et", "mt"})
+      .process(JoinStr({mc_processes, {"EMB"}}))
+      .AddSyst(cb, "CMS_eff_t_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.014));
+
+  // Tau ID: tt with 2 real taus
+  cb.cp()
+      .channel({"tt"})
+      .process(JoinStr({mc_processes, {"EMB"}}))
+      .AddSyst(cb, "CMS_eff_t_$ERA", "lnN", SystMap<>::init(1.064));
+
+  cb.cp()
+      .channel({"tt"})
+      .process(JoinStr({mc_processes, {"EMB"}}))
+      .AddSyst(cb, "CMS_eff_t_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.028));
+
   // Tau ID: tt with 1 real taus and 1 jet fake
   cb.cp()
       .channel({"tt"})
@@ -278,10 +279,27 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
   // - FIXME: References?
   // ##########################################################################
 
+  // MC uncorrelated uncertainty
+
+  cb.cp()
+      .channel({"em"})
+      .process(mc_processes)
+      .AddSyst(cb, "CMS_scale_mc_e_$ERA", "shape", SystMap<>::init(1.41));
+      
+  // Embedded uncorrelated uncertainty
+      
+  cb.cp()
+      .channel({"em"})
+      .process({"EMB"})
+      .AddSyst(cb, "CMS_scale_emb_e_$ERA", "shape", SystMap<>::init(1.41));
+
+  // MC + embedded correlated uncertainty
+
   cb.cp()
       .channel({"em"})
       .process(JoinStr({mc_processes, {"EMB"}}))
-      .AddSyst(cb, "CMS_scale_e_$ERA", "shape", SystMap<>::init(1.00));
+      .AddSyst(cb, "CMS_scale_e_$ERA", "shape", SystMap<>::init(1.41));
+
 
   // ##########################################################################
   // Uncertainty: Tau energy scale
@@ -291,43 +309,26 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
   // - FIXME: References?
   // ##########################################################################
 
-  cb.cp()
-      .channel({"et", "mt", "tt"})
-      .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "VVL"}}))
-      .AddSyst(cb, "CMS_scale_t_1prong_$ERA", "shape", SystMap<>::init(1.00));
 
-  cb.cp()
-      .channel({"et", "mt", "tt"})
-      .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "VVL"}}))
-      .AddSyst(cb, "CMS_scale_t_1prong1pizero_$ERA", "shape",
-               SystMap<>::init(1.00));
-
-  cb.cp()
-      .channel({"et", "mt", "tt"})
-      .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "VVL"}}))
-      .AddSyst(cb, "CMS_scale_t_3prong_$ERA", "shape", SystMap<>::init(1.00));
-
-  // 50% correlation for embedded
-  // correlated part
+  // MC uncorrelated uncertainty
 
   cb.cp()
       .channel({"et", "mt", "tt"})
       .process({"EMB"})
-      .AddSyst(cb, "CMS_scale_t_1prong_$ERA", "shape", SystMap<>::init(1.41));
+      .AddSyst(cb, "CMS_scale_mc_t_1prong_$ERA", "shape", SystMap<>::init(1.41));
 
   cb.cp()
       .channel({"et", "mt", "tt"})
       .process({"EMB"})
-      .AddSyst(cb, "CMS_scale_t_1prong1pizero_$ERA", "shape",
+      .AddSyst(cb, "CMS_scale_mc_t_1prong1pizero_$ERA", "shape",
                SystMap<>::init(1.41));
 
   cb.cp()
       .channel({"et", "mt", "tt"})
       .process({"EMB"})
-      .AddSyst(cb, "CMS_scale_t_3prong_$ERA", "shape", SystMap<>::init(1.41));
+      .AddSyst(cb, "CMS_scale_mc_t_3prong_$ERA", "shape", SystMap<>::init(1.41));
 
-  // 50% correlation for embedded
-  // uncorrelated part
+  // Embedded uncorrelated uncertainty
 
   cb.cp()
       .channel({"et", "mt", "tt"})
@@ -344,6 +345,24 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
       .channel({"et", "mt", "tt"})
       .process({"EMB"})
       .AddSyst(cb, "CMS_scale_emb_t_3prong_$ERA", "shape", SystMap<>::init(1.41));
+
+  // MC + embedded correlated uncertainty
+
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process({"EMB"})
+      .AddSyst(cb, "CMS_scale_t_1prong_$ERA", "shape", SystMap<>::init(1.41));
+
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process({"EMB"})
+      .AddSyst(cb, "CMS_scale_t_1prong1pizero_$ERA", "shape",
+               SystMap<>::init(1.41));
+
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process({"EMB"})
+      .AddSyst(cb, "CMS_scale_t_3prong_$ERA", "shape", SystMap<>::init(1.41));
 
 
   // ##########################################################################

--- a/HTTSM2017/src/HttSystematics_SMRun2.cc
+++ b/HTTSM2017/src/HttSystematics_SMRun2.cc
@@ -380,26 +380,40 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
                SystMap<>::init(1.00));
 
   // Electron fakes
-  cb.cp()
-      .channel({"et"})
-      .process({"ZL"})
-      .AddSyst(cb, "CMS_eFakeTau_1prong_$ERA", "shape", SystMap<>::init(1.00));
+  if (era == 2016) {
+      cb.cp()
+          .channel({"et"})
+          .process({"ZL"})
+          .AddSyst(cb, "CMS_eFakeTau_1prong_$ERA", "shape", SystMap<>::init(1.00));
 
-  cb.cp()
-      .channel({"et"})
-      .process({"ZL"})
-      .AddSyst(cb, "CMS_eFakeTau_1prong1pizero_$ERA", "shape", SystMap<>::init(1.00));
+      cb.cp()
+          .channel({"et"})
+          .process({"ZL"})
+          .AddSyst(cb, "CMS_eFakeTau_1prong1pizero_$ERA", "shape", SystMap<>::init(1.00));
+  }else if (era == 2017) {
+      cb.cp()
+          .channel({"et"})
+          .process({"ZL"})
+          .AddSyst(cb, "CMS_eFakeTau_$ERA", "lnN", SystMap<>::init(1.16));
+  }
 
   // Muon fakes
-  cb.cp()
-      .channel({"mt"})
-      .process({"ZL"})
-      .AddSyst(cb, "CMS_mFakeTau_1prong_$ERA", "shape", SystMap<>::init(1.00));
+  if (era == 2016) {
+      cb.cp()
+          .channel({"mt"})
+          .process({"ZL"})
+          .AddSyst(cb, "CMS_mFakeTau_1prong_$ERA", "shape", SystMap<>::init(1.00));
 
-  cb.cp()
-      .channel({"mt"})
-      .process({"ZL"})
-      .AddSyst(cb, "CMS_mFakeTau_1prong1pizero_$ERA", "shape", SystMap<>::init(1.00));
+      cb.cp()
+          .channel({"mt"})
+          .process({"ZL"})
+          .AddSyst(cb, "CMS_mFakeTau_1prong1pizero_$ERA", "shape", SystMap<>::init(1.00));
+  }else if (era == 2017) {
+      cb.cp()
+          .channel({"mt"})
+          .process({"ZL"})
+          .AddSyst(cb, "CMS_mFakeTau_$ERA", "lnN", SystMap<>::init(1.26));
+  }
 
   // ##########################################################################
   // Uncertainty: Jet to tau fakes

--- a/HTTSM2017/src/HttSystematics_SMRun2.cc
+++ b/HTTSM2017/src/HttSystematics_SMRun2.cc
@@ -413,7 +413,7 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
   // VV
   cb.cp()
       .channel({"et", "mt", "tt", "em"})
-      .process({"VVT", "VVJ"})
+      .process({"VVT", "VVJ", "VVL"})
       .AddSyst(cb, "CMS_htt_vvXsec_$ERA", "lnN", SystMap<>::init(1.05));
 
   // TT

--- a/HTTSM2017/src/HttSystematics_SMRun2.cc
+++ b/HTTSM2017/src/HttSystematics_SMRun2.cc
@@ -69,9 +69,9 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
 
   float lumi_unc = 1.0;
   if (era == 2016) {
-      lumi_unc = 1.025
-  }else if (era == 2017) {
-      lumi_unc = 1.023
+      lumi_unc = 1.025;
+  } else if (era == 2017) {
+      lumi_unc = 1.023;
   }
   cb.cp()
       .channel({"et", "mt", "tt", "em"})
@@ -512,7 +512,7 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
           .channel({"et"})
           .process({"ZL"})
           .AddSyst(cb, "CMS_eFakeTau_$ERA", "lnN", SystMap<>::init(1.155));
-  }else if (era == 2017) {
+  } else if (era == 2017) {
       cb.cp()
           .channel({"et"})
           .process({"ZL"})
@@ -525,7 +525,7 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
           .channel({"mt"})
           .process({"ZL"})
           .AddSyst(cb, "CMS_mFakeTau_$ERA", "lnN", SystMap<>::init(1.272));
-  }else if (era == 2017) {
+  } else if (era == 2017) {
       cb.cp()
           .channel({"mt"})
           .process({"ZL"})

--- a/HTTSM2017/src/HttSystematics_SMRun2.cc
+++ b/HTTSM2017/src/HttSystematics_SMRun2.cc
@@ -405,11 +405,11 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
       .AddSyst(cb, "CMS_scale_met_unclustered_$ERA", "shape", SystMap<>::init(1.00));
   cb.cp()
       .channel({"et", "mt", "tt", "em"})
-      .process(mc_processes)
+      .process(JoinStr({signals, {"ZTT", "ZL", "ZJ", "W"}}))
       .AddSyst(cb, "CMS_htt_boson_scale_met_$ERA", "shape", SystMap<>::init(1.00));
   cb.cp()
       .channel({"et", "mt", "tt", "em"})
-      .process(mc_processes)
+      .process(JoinStr({signals, {"ZTT", "ZL", "ZJ", "W"}}))
       .AddSyst(cb, "CMS_htt_boson_reso_met_$ERA", "shape", SystMap<>::init(1.00));
 
   // ##########################################################################

--- a/HTTSM2017/src/HttSystematics_SMRun2.cc
+++ b/HTTSM2017/src/HttSystematics_SMRun2.cc
@@ -67,10 +67,16 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
   // - FIXME: Adapt for fake factor and embedding
   // ##########################################################################
 
+  float lumi_unc = 1.0;
+  if (era == 2016) {
+      lumi_unc = 1.025
+  }else if (era == 2017) {
+      lumi_unc = 1.023
+  }
   cb.cp()
       .channel({"et", "mt", "tt", "em"})
       .process(mc_processes)
-      .AddSyst(cb, "lumi_$ERA", "lnN", SystMap<>::init(1.025));
+      .AddSyst(cb, "lumi_$ERA", "lnN", SystMap<>::init(lumi_unc));
 
   // ##########################################################################
   // Uncertainty: Trigger efficiency

--- a/HTTSM2017/src/HttSystematics_SMRun2.cc
+++ b/HTTSM2017/src/HttSystematics_SMRun2.cc
@@ -314,18 +314,18 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
 
   cb.cp()
       .channel({"et", "mt", "tt"})
-      .process(mc_processes)
+      .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "VVL"}}))
       .AddSyst(cb, "CMS_scale_mc_t_1prong_$ERA", "shape", SystMap<>::init(1.41));
 
   cb.cp()
       .channel({"et", "mt", "tt"})
-      .process(mc_processes)
+      .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "VVL"}}))
       .AddSyst(cb, "CMS_scale_mc_t_1prong1pizero_$ERA", "shape",
                SystMap<>::init(1.41));
 
   cb.cp()
       .channel({"et", "mt", "tt"})
-      .process(mc_processes)
+      .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "VVL"}}))
       .AddSyst(cb, "CMS_scale_mc_t_3prong_$ERA", "shape", SystMap<>::init(1.41));
 
   // Embedded uncorrelated uncertainty
@@ -350,18 +350,18 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
 
   cb.cp()
       .channel({"et", "mt", "tt"})
-      .process(JoinStr({mc_processes, {"EMB"}}))
+      .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "VVL"}, {"EMB"}}))
       .AddSyst(cb, "CMS_scale_t_1prong_$ERA", "shape", SystMap<>::init(1.41));
 
   cb.cp()
       .channel({"et", "mt", "tt"})
-      .process(JoinStr({mc_processes, {"EMB"}}))
+      .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "VVL"}, {"EMB"}}))
       .AddSyst(cb, "CMS_scale_t_1prong1pizero_$ERA", "shape",
                SystMap<>::init(1.41));
 
   cb.cp()
       .channel({"et", "mt", "tt"})
-      .process(JoinStr({mc_processes, {"EMB"}}))
+      .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "VVL"}, {"EMB"}}))
       .AddSyst(cb, "CMS_scale_t_3prong_$ERA", "shape", SystMap<>::init(1.41));
 
 

--- a/HTTSM2017/src/HttSystematics_SMRun2.cc
+++ b/HTTSM2017/src/HttSystematics_SMRun2.cc
@@ -48,7 +48,7 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
   /* // Not used in the function, keep it for documentation purposes.
   std::vector<std::string> backgrounds = {"ZTT",  "W",   "ZL",      "ZJ",
                                           "TTT",  "TTJ", "VVT",     "VVJ",
-                                          "EWKZ", "QCD", "jetFakes", "EMB", "TTL"};
+                                          "QCD", "jetFakes", "EMB", "TTL"};
   */
 
   // All processes being taken from simulation
@@ -56,7 +56,7 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
   std::vector<std::string> mc_processes =
       JoinStr({
               signals,
-              {"ZTT", "TTT", "TTL", "VVT", "EWKL", "EWKT", "EWKJ", "W", "ZJ", "ZL", "TTJ", "VVJ"}
+              {"ZTT", "TTT", "TTL", "VVT", "W", "ZJ", "ZL", "TTJ", "VVJ"}
               });
   // ##########################################################################
   // Uncertainty: Lumi
@@ -155,23 +155,23 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
   // Tau ID: tt with 2 real taus
   cb.cp()
       .channel({"tt"})
-      .process({"ZTT", "TTT", "VVT", "EWKT", "EMB"})
+      .process({"ZTT", "TTT", "VVT", "EMB"})
       .AddSyst(cb, "CMS_eff_t_$ERA", "lnN", SystMap<>::init(1.09));
 
   cb.cp()
       .channel({"tt"})
-      .process({"ZTT", "TTT", "VVT", "EWKT", "EMB"})
+      .process({"ZTT", "TTT", "VVT", "EMB"})
       .AddSyst(cb, "CMS_eff_t_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.04));
 
   // Tau ID: tt with 1 real taus and 1 jet fake
   cb.cp()
       .channel({"tt"})
-      .process({"W", "ZJ", "TTJ", "VVJ", "EWKJ"})
+      .process({"W", "ZJ", "TTJ", "VVJ"})
       .AddSyst(cb, "CMS_eff_t_$ERA", "lnN", SystMap<>::init(1.06));
 
   cb.cp()
       .channel({"tt"})
-      .process({"W", "ZJ", "TTJ", "VVJ", "EWKJ"})
+      .process({"W", "ZJ", "TTJ", "VVJ"})
       .AddSyst(cb, "CMS_eff_t_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.02));
 
   // ##########################################################################
@@ -213,18 +213,18 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
 
   cb.cp()
       .channel({"et", "mt", "tt"})
-      .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "VVL", "EWKT", "EMB"}}))
+      .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "VVL", "EMB"}}))
       .AddSyst(cb, "CMS_scale_t_1prong_$ERA", "shape", SystMap<>::init(1.00));
 
   cb.cp()
       .channel({"et", "mt", "tt"})
-      .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "VVL", "EWKT", "EMB"}}))
+      .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "VVL", "EMB"}}))
       .AddSyst(cb, "CMS_scale_t_1prong1pizero_$ERA", "shape",
                SystMap<>::init(1.00));
 
   cb.cp()
       .channel({"et", "mt", "tt"})
-      .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "VVL", "EWKT", "EMB"}}))
+      .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "VVL", "EMB"}}))
       .AddSyst(cb, "CMS_scale_t_3prong_$ERA", "shape", SystMap<>::init(1.00));
 
   // ##########################################################################
@@ -382,23 +382,23 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
   // Electron fakes
   cb.cp()
       .channel({"et"})
-      .process({"ZL", "EWKL"})
+      .process({"ZL"})
       .AddSyst(cb, "CMS_eFakeTau_1prong_$ERA", "shape", SystMap<>::init(1.00));
 
   cb.cp()
       .channel({"et"})
-      .process({"ZL", "EWKL"})
+      .process({"ZL"})
       .AddSyst(cb, "CMS_eFakeTau_1prong1pizero_$ERA", "shape", SystMap<>::init(1.00));
 
   // Muon fakes
   cb.cp()
       .channel({"mt"})
-      .process({"ZL", "EWKL"})
+      .process({"ZL"})
       .AddSyst(cb, "CMS_mFakeTau_1prong_$ERA", "shape", SystMap<>::init(1.00));
 
   cb.cp()
       .channel({"mt"})
-      .process({"ZL", "EWKL"})
+      .process({"ZL"})
       .AddSyst(cb, "CMS_mFakeTau_1prong1pizero_$ERA", "shape", SystMap<>::init(1.00));
 
   // ##########################################################################
@@ -411,7 +411,7 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
 
   cb.cp()
       .channel({"et", "mt", "tt"})
-      .process({"W", "TTJ", "ZJ", "VVJ", "EWKJ"})
+      .process({"W", "TTJ", "ZJ", "VVJ"})
       .AddSyst(cb, "CMS_htt_jetToTauFake_$ERA", "shape", SystMap<>::init(1.00));
 
   // ##########################################################################

--- a/HTTSM2017/src/HttSystematics_SMRun2.cc
+++ b/HTTSM2017/src/HttSystematics_SMRun2.cc
@@ -314,18 +314,18 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
 
   cb.cp()
       .channel({"et", "mt", "tt"})
-      .process({"EMB"})
+      .process(mc_processes)
       .AddSyst(cb, "CMS_scale_mc_t_1prong_$ERA", "shape", SystMap<>::init(1.41));
 
   cb.cp()
       .channel({"et", "mt", "tt"})
-      .process({"EMB"})
+      .process(mc_processes)
       .AddSyst(cb, "CMS_scale_mc_t_1prong1pizero_$ERA", "shape",
                SystMap<>::init(1.41));
 
   cb.cp()
       .channel({"et", "mt", "tt"})
-      .process({"EMB"})
+      .process(mc_processes)
       .AddSyst(cb, "CMS_scale_mc_t_3prong_$ERA", "shape", SystMap<>::init(1.41));
 
   // Embedded uncorrelated uncertainty
@@ -350,18 +350,18 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
 
   cb.cp()
       .channel({"et", "mt", "tt"})
-      .process({"EMB"})
+      .process(JoinStr({mc_processes, {"EMB"}}))
       .AddSyst(cb, "CMS_scale_t_1prong_$ERA", "shape", SystMap<>::init(1.41));
 
   cb.cp()
       .channel({"et", "mt", "tt"})
-      .process({"EMB"})
+      .process(JoinStr({mc_processes, {"EMB"}}))
       .AddSyst(cb, "CMS_scale_t_1prong1pizero_$ERA", "shape",
                SystMap<>::init(1.41));
 
   cb.cp()
       .channel({"et", "mt", "tt"})
-      .process({"EMB"})
+      .process(JoinStr({mc_processes, {"EMB"}}))
       .AddSyst(cb, "CMS_scale_t_3prong_$ERA", "shape", SystMap<>::init(1.41));
 
 

--- a/HTTSM2017/src/HttSystematics_SMRun2.cc
+++ b/HTTSM2017/src/HttSystematics_SMRun2.cc
@@ -539,11 +539,6 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
       .process({"EMB"})
       .AddSyst(cb, "CMS_htt_doublemutrg_$ERA", "lnN", SystMap<>::init(1.04));
 
-  cb.cp()
-      .channel({"tt"})
-      .process({"EMB"})
-      .AddSyst(cb, "CMS_htt_doubletautrg_$ERA", "lnN", SystMap<>::init(1.04));
-
   // TTbar contamination in embedded events: 10% shape uncertainty of assumed ttbar->tautau event shape
   cb.cp()
     .channel({"et", "mt", "tt", "em"})

--- a/HTTSM2017/src/HttSystematics_SMRun2.cc
+++ b/HTTSM2017/src/HttSystematics_SMRun2.cc
@@ -132,36 +132,110 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
   // Electron ID
   cb.cp()
       .channel({"et", "em"})
-      .process(JoinStr({mc_processes, {"EMB"}}))
+      .process(mc_processes)
       .AddSyst(cb, "CMS_eff_e_$ERA", "lnN", SystMap<>::init(1.02));
 
   // Muon ID
   cb.cp()
       .channel({"mt", "em"})
-      .process(JoinStr({mc_processes, {"EMB"}}))
+      .process(mc_processes)
       .AddSyst(cb, "CMS_eff_m_$ERA", "lnN", SystMap<>::init(1.02));
 
   // Tau ID: et and mt with 1 real tau
   cb.cp()
       .channel({"et", "mt"})
-      .process(JoinStr({mc_processes, {"EMB"}}))
+      .process(mc_processes)
       .AddSyst(cb, "CMS_eff_t_$ERA", "lnN", SystMap<>::init(1.045));
 
   cb.cp()
       .channel({"et", "mt"})
-      .process(JoinStr({mc_processes, {"EMB"}}))
+      .process(mc_processes)
       .AddSyst(cb, "CMS_eff_t_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.02));
 
   // Tau ID: tt with 2 real taus
   cb.cp()
       .channel({"tt"})
-      .process({"ZTT", "TTT", "VVT", "EMB"})
+      .process({"ZTT", "TTT", "VVT"})
       .AddSyst(cb, "CMS_eff_t_$ERA", "lnN", SystMap<>::init(1.09));
 
   cb.cp()
       .channel({"tt"})
-      .process({"ZTT", "TTT", "VVT", "EMB"})
+      .process({"ZTT", "TTT", "VVT"})
       .AddSyst(cb, "CMS_eff_t_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.04));
+
+  // 50% correlation for embedded
+  // correlated part
+
+  // Electron ID
+  cb.cp()
+      .channel({"et", "em"})
+      .process({"EMB"})
+      .AddSyst(cb, "CMS_eff_e_$ERA", "lnN", SystMap<>::init(1.014));
+
+  // Muon ID
+  cb.cp()
+      .channel({"mt", "em"})
+      .process({"EMB"})
+      .AddSyst(cb, "CMS_eff_m_$ERA", "lnN", SystMap<>::init(1.014));
+
+  // Tau ID: et and mt with 1 real tau
+  cb.cp()
+      .channel({"et", "mt"})
+      .process({"EMB"})
+      .AddSyst(cb, "CMS_eff_t_$ERA", "lnN", SystMap<>::init(1.032));
+
+  cb.cp()
+      .channel({"et", "mt"})
+      .process({"EMB"})
+      .AddSyst(cb, "CMS_eff_t_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.014));
+
+  // Tau ID: tt with 2 real taus
+  cb.cp()
+      .channel({"tt"})
+      .process({"EMB"})
+      .AddSyst(cb, "CMS_eff_t_$ERA", "lnN", SystMap<>::init(1.064));
+
+  cb.cp()
+      .channel({"tt"})
+      .process({"EMB"})
+      .AddSyst(cb, "CMS_eff_t_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.028));
+      
+  // uncorrelated part
+  
+  // Electron ID
+  cb.cp()
+      .channel({"et", "em"})
+      .process({"EMB"})
+      .AddSyst(cb, "CMS_eff_emb_e_$ERA", "lnN", SystMap<>::init(1.014));
+
+  // Muon ID
+  cb.cp()
+      .channel({"mt", "em"})
+      .process({"EMB"})
+      .AddSyst(cb, "CMS_eff_emb_m_$ERA", "lnN", SystMap<>::init(1.014));
+
+  // Tau ID: et and mt with 1 real tau
+  cb.cp()
+      .channel({"et", "mt"})
+      .process({"EMB"})
+      .AddSyst(cb, "CMS_eff_emb_t_$ERA", "lnN", SystMap<>::init(1.032));
+
+  cb.cp()
+      .channel({"et", "mt"})
+      .process({"EMB"})
+      .AddSyst(cb, "CMS_eff_emb_t_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.014));
+
+  // Tau ID: tt with 2 real taus
+  cb.cp()
+      .channel({"tt"})
+      .process({"EMB"})
+      .AddSyst(cb, "CMS_eff_emb_t_$ERA", "lnN", SystMap<>::init(1.064));
+
+  cb.cp()
+      .channel({"tt"})
+      .process({"EMB"})
+      .AddSyst(cb, "CMS_eff_emb_t_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.028));
+
 
   // Tau ID: tt with 1 real taus and 1 jet fake
   cb.cp()
@@ -213,19 +287,58 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
 
   cb.cp()
       .channel({"et", "mt", "tt"})
-      .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "VVL", "EMB"}}))
+      .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "VVL"}}))
       .AddSyst(cb, "CMS_scale_t_1prong_$ERA", "shape", SystMap<>::init(1.00));
 
   cb.cp()
       .channel({"et", "mt", "tt"})
-      .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "VVL", "EMB"}}))
+      .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "VVL"}}))
       .AddSyst(cb, "CMS_scale_t_1prong1pizero_$ERA", "shape",
                SystMap<>::init(1.00));
 
   cb.cp()
       .channel({"et", "mt", "tt"})
-      .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "VVL", "EMB"}}))
+      .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "VVL"}}))
       .AddSyst(cb, "CMS_scale_t_3prong_$ERA", "shape", SystMap<>::init(1.00));
+
+  // 50% correlation for embedded
+  // correlated part
+  
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process({"EMB"})
+      .AddSyst(cb, "CMS_scale_t_1prong_$ERA", "shape", SystMap<>::init(1.41));
+
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process({"EMB"})
+      .AddSyst(cb, "CMS_scale_t_1prong1pizero_$ERA", "shape",
+               SystMap<>::init(1.41));
+
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process({"EMB"})
+      .AddSyst(cb, "CMS_scale_t_3prong_$ERA", "shape", SystMap<>::init(1.41));
+      
+  // 50% correlation for embedded
+  // uncorrelated part
+
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process({"EMB"})
+      .AddSyst(cb, "CMS_scale_emb_t_1prong_$ERA", "shape", SystMap<>::init(1.41));
+
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process({"EMB"})
+      .AddSyst(cb, "CMS_scale_emb_t_1prong1pizero_$ERA", "shape",
+               SystMap<>::init(1.41));
+
+  cb.cp()
+      .channel({"et", "mt", "tt"})
+      .process({"EMB"})
+      .AddSyst(cb, "CMS_scale_emb_t_3prong_$ERA", "shape", SystMap<>::init(1.41));
+
 
   // ##########################################################################
   // Uncertainty: Jet energy scale

--- a/HTTSM2017/src/HttSystematics_SMRun2.cc
+++ b/HTTSM2017/src/HttSystematics_SMRun2.cc
@@ -386,7 +386,7 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
   }
 
   // ##########################################################################
-  // Uncertainty: MET energy scale
+  // Uncertainty: MET energy scale and Recoil
   // References:
   // Notes:
   // - FIXME: Clustered vs unclustered MET? Inclusion of JES splitting?
@@ -397,6 +397,14 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
       .channel({"et", "mt", "tt", "em"})
       .process(mc_processes)
       .AddSyst(cb, "CMS_scale_met_unclustered_$ERA", "shape", SystMap<>::init(1.00));
+  cb.cp()
+      .channel({"et", "mt", "tt", "em"})
+      .process(mc_processes)
+      .AddSyst(cb, "CMS_htt_boson_scale_met_$ERA", "shape", SystMap<>::init(1.00));
+  cb.cp()
+      .channel({"et", "mt", "tt", "em"})
+      .process(mc_processes)
+      .AddSyst(cb, "CMS_htt_boson_reso_met_$ERA", "shape", SystMap<>::init(1.00));
 
   // ##########################################################################
   // Uncertainty: Background normalizations

--- a/HTTSM2017/src/HttSystematics_SMRun2.cc
+++ b/HTTSM2017/src/HttSystematics_SMRun2.cc
@@ -56,7 +56,7 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
   std::vector<std::string> mc_processes =
       JoinStr({
               signals,
-              {"ZTT", "TTT", "TTL", "VVT", "W", "ZJ", "ZL", "TTJ", "VVJ"}
+              {"ZTT", "TTT", "TTL", "VVT", "W", "ZJ", "ZL", "TTJ", "VVL", "VVJ"}
               });
   // ##########################################################################
   // Uncertainty: Lumi

--- a/HTTSM2017/src/HttSystematics_SMRun2.cc
+++ b/HTTSM2017/src/HttSystematics_SMRun2.cc
@@ -81,23 +81,44 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
 
   cb.cp()
       .channel({"et"})
-      .process(JoinStr({mc_processes, {"EMB"}}))
+      .process(mc_processes)
       .AddSyst(cb, "CMS_eff_trigger_et_$ERA", "lnN", SystMap<>::init(1.02));
 
   cb.cp()
       .channel({"mt"})
-      .process(JoinStr({mc_processes, {"EMB"}}))
+      .process(mc_processes)
       .AddSyst(cb, "CMS_eff_trigger_mt_$ERA", "lnN", SystMap<>::init(1.02));
 
   cb.cp()
       .channel({"tt"})
-      .process(JoinStr({mc_processes, {"EMB"}}))
+      .process(mc_processes)
       .AddSyst(cb, "CMS_eff_trigger_tt_$ERA", "lnN", SystMap<>::init(1.02));
 
   cb.cp()
       .channel({"em"})
-      .process(JoinStr({mc_processes, {"EMB"}}))
+      .process(mc_processes)
       .AddSyst(cb, "CMS_eff_trigger_em_$ERA", "lnN", SystMap<>::init(1.02));
+
+  // should be de-correlated for embedded
+  cb.cp()
+      .channel({"et"})
+      .process({"EMB"})
+      .AddSyst(cb, "CMS_eff_trigger_emb_et_$ERA", "lnN", SystMap<>::init(1.02));
+
+  cb.cp()
+      .channel({"mt"})
+      .process({"EMB"})
+      .AddSyst(cb, "CMS_eff_trigger_emb_mt_$ERA", "lnN", SystMap<>::init(1.02));
+
+  cb.cp()
+      .channel({"tt"})
+      .process({"EMB"})
+      .AddSyst(cb, "CMS_eff_trigger_emb_tt_$ERA", "lnN", SystMap<>::init(1.02));
+
+  cb.cp()
+      .channel({"em"})
+      .process({"EMB"})
+      .AddSyst(cb, "CMS_eff_trigger_emb_em_$ERA", "lnN", SystMap<>::init(1.02));
 
   // ##########################################################################
   // Uncertainty: Electron, muon and tau ID efficiency
@@ -503,6 +524,11 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
       .channel({"et", "mt", "tt", "em"})
       .process({"EMB"})
       .AddSyst(cb, "CMS_htt_doublemutrg_$ERA", "lnN", SystMap<>::init(1.04));
+
+  cb.cp()
+      .channel({"tt"})
+      .process({"EMB"})
+      .AddSyst(cb, "CMS_htt_doubletautrg_$ERA", "lnN", SystMap<>::init(1.04));
 
   // TTbar contamination in embedded events: 10% shape uncertainty of assumed ttbar->tautau event shape
   cb.cp()

--- a/HTTSM2017/src/HttSystematics_SMRun2.cc
+++ b/HTTSM2017/src/HttSystematics_SMRun2.cc
@@ -284,21 +284,21 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
   cb.cp()
       .channel({"em"})
       .process(mc_processes)
-      .AddSyst(cb, "CMS_scale_mc_e_$ERA", "shape", SystMap<>::init(1.41));
+      .AddSyst(cb, "CMS_scale_mc_e_$ERA", "shape", SystMap<>::init(0.71));
       
   // Embedded uncorrelated uncertainty
       
   cb.cp()
       .channel({"em"})
       .process({"EMB"})
-      .AddSyst(cb, "CMS_scale_emb_e_$ERA", "shape", SystMap<>::init(1.41));
+      .AddSyst(cb, "CMS_scale_emb_e_$ERA", "shape", SystMap<>::init(0.71));
 
   // MC + embedded correlated uncertainty
 
   cb.cp()
       .channel({"em"})
       .process(JoinStr({mc_processes, {"EMB"}}))
-      .AddSyst(cb, "CMS_scale_e_$ERA", "shape", SystMap<>::init(1.41));
+      .AddSyst(cb, "CMS_scale_e_$ERA", "shape", SystMap<>::init(0.71));
 
 
   // ##########################################################################
@@ -315,54 +315,52 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
   cb.cp()
       .channel({"et", "mt", "tt"})
       .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "VVL"}}))
-      .AddSyst(cb, "CMS_scale_mc_t_1prong_$ERA", "shape", SystMap<>::init(1.41));
+      .AddSyst(cb, "CMS_scale_mc_t_1prong_$ERA", "shape", SystMap<>::init(0.71));
 
   cb.cp()
       .channel({"et", "mt", "tt"})
       .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "VVL"}}))
       .AddSyst(cb, "CMS_scale_mc_t_1prong1pizero_$ERA", "shape",
-               SystMap<>::init(1.41));
+               SystMap<>::init(0.71));
 
   cb.cp()
       .channel({"et", "mt", "tt"})
       .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "VVL"}}))
-      .AddSyst(cb, "CMS_scale_mc_t_3prong_$ERA", "shape", SystMap<>::init(1.41));
+      .AddSyst(cb, "CMS_scale_mc_t_3prong_$ERA", "shape", SystMap<>::init(0.71));
 
   // Embedded uncorrelated uncertainty
 
   cb.cp()
       .channel({"et", "mt", "tt"})
       .process({"EMB"})
-      .AddSyst(cb, "CMS_scale_emb_t_1prong_$ERA", "shape", SystMap<>::init(1.41));
+      .AddSyst(cb, "CMS_scale_emb_t_1prong_$ERA", "shape", SystMap<>::init(0.71));
 
   cb.cp()
       .channel({"et", "mt", "tt"})
       .process({"EMB"})
-      .AddSyst(cb, "CMS_scale_emb_t_1prong1pizero_$ERA", "shape",
-               SystMap<>::init(1.41));
+      .AddSyst(cb, "CMS_scale_emb_t_1prong1pizero_$ERA", "shape", SystMap<>::init(0.71));
 
   cb.cp()
       .channel({"et", "mt", "tt"})
       .process({"EMB"})
-      .AddSyst(cb, "CMS_scale_emb_t_3prong_$ERA", "shape", SystMap<>::init(1.41));
+      .AddSyst(cb, "CMS_scale_emb_t_3prong_$ERA", "shape", SystMap<>::init(0.71));
 
   // MC + embedded correlated uncertainty
 
   cb.cp()
       .channel({"et", "mt", "tt"})
       .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "VVL"}, {"EMB"}}))
-      .AddSyst(cb, "CMS_scale_t_1prong_$ERA", "shape", SystMap<>::init(1.41));
+      .AddSyst(cb, "CMS_scale_t_1prong_$ERA", "shape", SystMap<>::init(0.71));
 
   cb.cp()
       .channel({"et", "mt", "tt"})
       .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "VVL"}, {"EMB"}}))
-      .AddSyst(cb, "CMS_scale_t_1prong1pizero_$ERA", "shape",
-               SystMap<>::init(1.41));
+      .AddSyst(cb, "CMS_scale_t_1prong1pizero_$ERA", "shape", SystMap<>::init(0.71));
 
   cb.cp()
       .channel({"et", "mt", "tt"})
       .process(JoinStr({signals, {"ZTT", "TTT", "TTL", "VVT", "VVL"}, {"EMB"}}))
-      .AddSyst(cb, "CMS_scale_t_3prong_$ERA", "shape", SystMap<>::init(1.41));
+      .AddSyst(cb, "CMS_scale_t_3prong_$ERA", "shape", SystMap<>::init(0.71));
 
 
   // ##########################################################################

--- a/HTTSM2017/src/HttSystematics_SMRun2.cc
+++ b/HTTSM2017/src/HttSystematics_SMRun2.cc
@@ -48,7 +48,7 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
   /* // Not used in the function, keep it for documentation purposes.
   std::vector<std::string> backgrounds = {"ZTT",  "W",   "ZL",      "ZJ",
                                           "TTT",  "TTJ", "VVT",     "VVJ",
-                                          "QCD", "jetFakes", "EMB", "TTL"};
+                                          "EWKZ", "QCD", "jetFakes", "EMB", "TTL"};
   */
 
   // All processes being taken from simulation
@@ -56,7 +56,7 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
   std::vector<std::string> mc_processes =
       JoinStr({
               signals,
-              {"ZTT", "TTT", "TTL", "VVT", "W", "ZJ", "ZL", "TTJ", "VVL", "VVJ"}
+              {"ZTT", "TT", "TTT", "TTL", "TTJ", "W", "ZJ", "ZL", "VV", "VVT", "VVL", "VVJ", "ST"}
               });
   // ##########################################################################
   // Uncertainty: Lumi
@@ -205,9 +205,9 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
       .channel({"tt"})
       .process({"EMB"})
       .AddSyst(cb, "CMS_eff_t_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.028));
-      
+
   // uncorrelated part
-  
+
   // Electron ID
   cb.cp()
       .channel({"et", "em"})
@@ -309,7 +309,7 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
 
   // 50% correlation for embedded
   // correlated part
-  
+
   cb.cp()
       .channel({"et", "mt", "tt"})
       .process({"EMB"})
@@ -325,7 +325,7 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
       .channel({"et", "mt", "tt"})
       .process({"EMB"})
       .AddSyst(cb, "CMS_scale_t_3prong_$ERA", "shape", SystMap<>::init(1.41));
-      
+
   // 50% correlation for embedded
   // uncorrelated part
 
@@ -356,7 +356,7 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
 
   if (!regional_jec) {
   cb.cp()
-      .channel({"et", "mt", "tt"})
+      .channel({"et", "mt", "tt", "em"})
       .process(mc_processes)
       .AddSyst(cb, "CMS_scale_j_$ERA", "shape", SystMap<>::init(1.00));
   }
@@ -427,13 +427,13 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
   // VV
   cb.cp()
       .channel({"et", "mt", "tt", "em"})
-      .process({"VVT", "VVJ", "VVL"})
+      .process({"VVT", "VVJ", "VVL", "VV", "ST"})
       .AddSyst(cb, "CMS_htt_vvXsec_$ERA", "lnN", SystMap<>::init(1.05));
 
   // TT
   cb.cp()
       .channel({"et", "mt", "tt", "em"})
-      .process({"TTT", "TTL", "TTJ"})
+      .process({"TTT", "TTL", "TTJ", "TT"})
       .AddSyst(cb, "CMS_htt_tjXsec_$ERA", "lnN", SystMap<>::init(1.06));
 
   // W
@@ -461,6 +461,10 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
       .channel({"tt"})
       .process({"QCD"})
       .AddSyst(cb, "CMS_ExtrapABCD_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.03));
+  cb.cp()
+      .channel({"em"})
+      .process({"QCD"})
+      .AddSyst(cb, "CMS_ExtrapSSOS_$CHANNEL_$ERA", "lnN", SystMap<>::init(1.10));
 
   // ##########################################################################
   // Uncertainty: Drell-Yan LO->NLO reweighting
@@ -483,7 +487,7 @@ void AddSMRun2Systematics(CombineHarvester &cb, bool jetfakes, bool embedding, b
 
   cb.cp()
       .channel({"et", "mt", "tt", "em"})
-      .process({"TTT", "TTL", "TTJ"})
+      .process({"TTT", "TTL", "TTJ", "TT"})
       .AddSyst(cb, "CMS_htt_ttbarShape_$ERA", "shape", SystMap<>::init(1.00));
 
   // ##########################################################################


### PR DESCRIPTION
@mflechl We've put in following changes:

1. Remove EWKZ process (merged to DY)
2. Introduce TTL and VVL process splitting
3. Set lumi uncertainty for 2017
4. Decorrelate trigger efficiency for embedding
5. Partially correlate tau ID efficiency for embedding
6. Add recoil correction uncertainties
7. Remove decay mode dependent lepton to tau fake rates and implement log-normal uncertainties such as recommended