### PR TITLE
Overload method for CombineHarvester::WriteDatacard with TFile

### DIFF
--- a/CombineTools/interface/CombineHarvester_Python.h
+++ b/CombineTools/interface/CombineHarvester_Python.h
@@ -27,6 +27,8 @@ void CloneSystsPy(ch::CombineHarvester& src, ch::CombineHarvester& dest,
 void CloneProcsAndSystsPy(ch::CombineHarvester& src, ch::CombineHarvester& dest,
                         boost::python::object func);
 
+void Overload3_WriteDatacard(ch::CombineHarvester & cb, std::string const& name, bp::object& file);
+
 /**
  * Covert a C++ ROOT type to a PyROOT type
  */

--- a/CombineTools/src/CombineHarvester_Python.cc
+++ b/CombineTools/src/CombineHarvester_Python.cc
@@ -129,6 +129,13 @@ void (CombineHarvester::*Overload1_WriteDatacard)(
 void (CombineHarvester::*Overload2_WriteDatacard)(
     std::string const&) = &CombineHarvester::WriteDatacard;
 
+void Overload3_WriteDatacard(ch::CombineHarvester& cb, std::string const& name, bp::object& file){
+  TFile *file_ = nullptr;
+  if (!file.is_none())
+    file_ = (TFile*)(TPython::ObjectProxy_AsVoidPtr(file.ptr()));
+  cb.WriteDatacard(name,*file_);
+}
+
 double (CombineHarvester::*Overload1_GetUncertainty)(
     void) = &CombineHarvester::GetUncertainty;
 
@@ -151,7 +158,7 @@ void (CombineHarvester::*Overload_AddBinByBin)(
     double, bool, CombineHarvester &) = &CombineHarvester::AddBinByBin;
 
 void (Observation::*Overload_Obs_set_shape)(
-    TH1 const& ,bool) = &Observation::set_shape;
+    TH1 const&, bool) = &Observation::set_shape;
 
 void (Process::*Overload_Proc_set_shape)(
     TH1 const&, bool) = &Process::set_shape;
@@ -214,7 +221,7 @@ BOOST_PYTHON_MODULE(libCombineHarvesterCombineTools)
 
   py::to_python_converter<RooWorkspace,
                           convert_cpp_root_to_py_root<RooWorkspace>>();
-
+  
   // Define converters from python --> C++
   convert_py_seq_to_cpp_vector<std::string>();
   convert_py_tup_to_cpp_pair<int, std::string>();
@@ -253,6 +260,7 @@ BOOST_PYTHON_MODULE(libCombineHarvesterCombineTools)
       .def("QuickParseDatacard", Overload2_ParseDatacard)
       .def("WriteDatacard", Overload1_WriteDatacard)
       .def("WriteDatacard", Overload2_WriteDatacard)
+      .def("WriteDatacard", Overload3_WriteDatacard)
       // Filters
       .def("bin", &CombineHarvester::bin,
           defaults_bin()[py::return_internal_reference<>()])


### PR DESCRIPTION
Add a method to overload 
```
CombineHarvester::WriteDatacard(std::string const& name, TFile& root_file)
```
for use in python. I noticed [this was not possible yet](http://cms-analysis.github.io/CombineHarvester/python-interface.html#py-datacards-writing), so I took inspiration from [`CombineHarvester/CombinePdfs/src/Python.cc::BuildRooMorphingPy`](https://github.com/cms-analysis/CombineHarvester/blob/master/CombinePdfs/src/Python.cc#L8).

You might want to double-check the use of pointers/references, as I am not an C++ expert, but these changes allowed me to do
```
harvester = CombineHarvester()
...
output = TFile("htt_mt.input.root", 'RECREATE')
for mass in masses:
  harvester.cp().mass([mass,'*']).WriteDatacard("htt_mt.datacard_M%s.root"%mass,outfile)
outfile.Close()
```
Where in the end, you have one datacard for each mass point, and one single root file with one directory per bin containing all common background histograms, as well as the signal histograms for each mass point.