### PR TITLE
make impacts work on workspaces with > 100 processes per channel

### DIFF
--- a/CombineTools/python/combine/Impacts.py
+++ b/CombineTools/python/combine/Impacts.py
@@ -7,6 +7,7 @@ import ROOT
 import CombineHarvester.CombineTools.combine.utils as utils
 
 from CombineHarvester.CombineTools.combine.CombineToolBase import CombineToolBase
+from HiggsAnalysis.CombinedLimit.RooAddPdfFixer import FixAll
 
 
 class Impacts(CombineToolBase):
@@ -226,7 +227,9 @@ class Impacts(CombineToolBase):
     def all_free_parameters(self, file, wsp, mc, pois):
         res = []
         wsFile = ROOT.TFile.Open(file)
-        config = wsFile.Get(wsp).genobj(mc)
+        w = wsFile.Get(wsp)
+        FixAll(w)
+        config = w.genobj(mc)
         pdfvars = config.GetPdf().getParameters(config.GetObservables())
         it = pdfvars.createIterator()
         var = it.Next()

--- a/CombineTools/python/combine/Impacts.py
+++ b/CombineTools/python/combine/Impacts.py
@@ -7,7 +7,12 @@ import ROOT
 import CombineHarvester.CombineTools.combine.utils as utils
 
 from CombineHarvester.CombineTools.combine.CombineToolBase import CombineToolBase
-from HiggsAnalysis.CombinedLimit.RooAddPdfFixer import FixAll
+try:
+    from HiggsAnalysis.CombinedLimit.RooAddPdfFixer import FixAll
+except ImportError:
+    #compatibility for combine version earlier than https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/tree/2d172ef50fccdfbbc2a499ac8e47bba2d667b95a
+    #can delete in a few months
+    def FixAll(workspace): pass
 
 
 class Impacts(CombineToolBase):

--- a/CombineTools/python/combine/utils.py
+++ b/CombineTools/python/combine/utils.py
@@ -1,6 +1,8 @@
 import ROOT
 import re
 
+from HiggsAnalysis.CombinedLimit.RooAddPdfFixer import FixAll
+
 def split_vals(vals, fmt_spec=None):
     """Converts a string '1:3|1,4,5' into a list [1, 2, 3, 4, 5]"""
     res = set()
@@ -29,7 +31,9 @@ def list_from_workspace(file, workspace, set):
     """Create a list of strings from a RooWorkspace set"""
     res = []
     wsFile = ROOT.TFile(file)
-    argSet = wsFile.Get(workspace).set(set)
+    ws = wsFile.Get(workspace)
+    FixAll(ws)
+    argSet = ws.set(set)
     it = argSet.createIterator()
     var = it.Next()
     while var:
@@ -43,6 +47,7 @@ def prefit_from_workspace(file, workspace, params, setPars=None):
     res = {}
     wsFile = ROOT.TFile(file)
     ws = wsFile.Get(workspace)
+    FixAll(ws)
     ROOT.RooMsgService.instance().setGlobalKillBelow(ROOT.RooFit.WARNING)
     if setPars is not None:
       parsToSet = [tuple(x.split('=')) for x in setPars.split(',')]

--- a/CombineTools/python/combine/utils.py
+++ b/CombineTools/python/combine/utils.py
@@ -1,7 +1,12 @@
 import ROOT
 import re
 
-from HiggsAnalysis.CombinedLimit.RooAddPdfFixer import FixAll
+try:
+    from HiggsAnalysis.CombinedLimit.RooAddPdfFixer import FixAll
+except ImportError:
+    #compatibility for combine version earlier than https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/tree/2d172ef50fccdfbbc2a499ac8e47bba2d667b95a
+    #can delete in a few months
+    def FixAll(workspace): pass
 
 def split_vals(vals, fmt_spec=None):
     """Converts a string '1:3|1,4,5' into a list [1, 2, 3, 4, 5]"""


### PR DESCRIPTION
This fixes the same segmentation fault as cms-analysis/HiggsAnalysis-CombinedLimit#559.  That fix only applied when you open the workspace in the combine C++ code.  When running impacts we open the workspace independently of that, so the fix doesn't get applied.

I may have missed some other places in CombineHarvester where this needs to happen as well... this is just in the impacts step.

This needs cms-analysis/HiggsAnalysis-CombinedLimit#562 to be merged first