### PR TITLE
Adding additional checks to datacard validation tool

### DIFF
--- a/CombineTools/interface/ValidationTools.h
+++ b/CombineTools/interface/ValidationTools.h
@@ -28,13 +28,17 @@ void ValidateShapeUncertaintyDirection(CombineHarvester& cb, json &jsobj);
 void ValidateShapeUncertaintyDirection(CombineHarvester& cb);
 void CheckEmptyShapes(CombineHarvester& cb, json &jsobj);
 void CheckEmptyShapes(CombineHarvester& cb);
+void CheckEmptyBins(CombineHarvester& cb, json &jsobj);
+void CheckEmptyBins(CombineHarvester& cb);
 void CheckNormEff(CombineHarvester& cb, double maxNormEff, json &jsobj);
 void CheckNormEff(CombineHarvester& cb, double maxNormEff);
 void CheckSizeOfShapeEffect(CombineHarvester& cb, json& jsobj);
 void CheckSizeOfShapeEffect(CombineHarvester& cb);
-void CheckSmallSignals(CombineHarvester& cb, json& jsobj);
-void CheckSmallSignals(CombineHarvester& cb);
-void ValidateCards(CombineHarvester& cb, std::string const& filename, double maxNormEff);
+void CheckSmallSignals(CombineHarvester& cb, double minSigFrac, json& jsobj);
+void CheckSmallSignals(CombineHarvester& cb, double minSigFrac);
+void ValidateShapeTemplates(CombineHarvester& cb, json &jsobj);
+void ValidateShapeTemplates(CombineHarvester& cb);
+void ValidateCards(CombineHarvester& cb, std::string const& filename, double maxNormEff, double minSigFrac);
 
 }
 

--- a/CombineTools/interface/ValidationTools.h
+++ b/CombineTools/interface/ValidationTools.h
@@ -32,6 +32,8 @@ void CheckNormEff(CombineHarvester& cb, double maxNormEff, json &jsobj);
 void CheckNormEff(CombineHarvester& cb, double maxNormEff);
 void CheckSizeOfShapeEffect(CombineHarvester& cb, json& jsobj);
 void CheckSizeOfShapeEffect(CombineHarvester& cb);
+void CheckSmallSignals(CombineHarvester& cb, json& jsobj);
+void CheckSmallSignals(CombineHarvester& cb);
 void ValidateCards(CombineHarvester& cb, std::string const& filename, double maxNormEff);
 
 }

--- a/CombineTools/scripts/ValidateDatacards.py
+++ b/CombineTools/scripts/ValidateDatacards.py
@@ -22,6 +22,8 @@ parser.add_argument('--readOnly', action='store_true',
                     help='If this is enabled, skip validation and only read the output json')
 parser.add_argument('--checkUncertOver', '-c', default=0.1, type=float,
                     help='Report uncertainties which have a normalisation effect larger than this fraction')
+parser.add_argument('--reportSigUnder', '-s', default=0.001, type=float,
+                    help='Report signals contributing less than this fraction of the total in a channel')
 parser.add_argument('--jsonFile', default='validation.json',
                     help='Path to the json file to read/write results from')
 parser.add_argument('--mass', default='*',
@@ -81,6 +83,21 @@ def print_process_info(js_dict, dict_key, err_type_msg):
     else:
       print ">>>There were no alerts of type", err_type_msg
 
+def print_bin(js_dict, dict_key, err_type_msg):
+    num_problems=0
+    num_problems_peruncert = {}
+    if dict_key in js_dict: 
+      for mybin in js_dict[dict_key]:
+        probs=0;
+        num_problems+=len(js_dict[dict_key][mybin])
+        num_problems_peruncert[mybin]=len(js_dict[dict_key][mybin])
+      print ">>>There were ",num_problems, "warnings of type ",err_type_msg
+      if args.printLevel > 1:
+        for mybin in js_dict[dict_key]:
+          print "    For bin",mybin, "there were ", num_problems_peruncert[mybin]," such warnings. The affected bins of the template are: ", json.dumps(js_dict[dict_key][mybin])
+    else:
+      print ">>>There were no warnings of type", err_type_msg
+
 
 
 cb = ch.CombineHarvester()
@@ -90,7 +107,7 @@ cb.SetFlag('workspaces-use-clone', True)
 if not args.readOnly: 
   cb.ParseDatacard(args.cards,"","",mass=args.mass)
 
-  ch.ValidateCards(cb,args.jsonFile,args.checkUncertOver)
+  ch.ValidateCards(cb,args.jsonFile,args.checkUncertOver,args.reportSigUnder)
 
 if args.printLevel > 0:
   print "================================" 
@@ -102,10 +119,12 @@ if args.printLevel > 0:
       print ">>>There were no warnings"
     else :
       print_uncertainty(data,"uncertVarySameDirect","\'up/down templates vary the yield in the same direction\'")
+      print_uncertainty(data,"uncertTemplSame","\'up/down templates are identical\'")
       print_uncertainty(data,"emptySystematicShape","\'At least one of the up/down systematic uncertainty templates is empty\'")
       print_uncertainty(data,"largeNormEff","\'Uncertainty has normalisation effect of more than %.1f%%\'"% (args.checkUncertOver*100))
       print_uncertainty(data,"smallShapeEff","\'Uncertainty probably has no genuine shape effect\'")
       print_process(data,"emptyProcessShape","\'Empty process\'")
+      print_bin(data,"emptyBkgBin","\'Bins of the template empty in background\'")
       print_process_info(data,"smallSignalProc","\'Small signal process\'")
 
 

--- a/CombineTools/scripts/ValidateDatacards.py
+++ b/CombineTools/scripts/ValidateDatacards.py
@@ -66,6 +66,22 @@ def print_process(js_dict, dict_key, err_type_msg):
     else:
       print ">>>There were no warnings of type", err_type_msg
 
+def print_process_info(js_dict, dict_key, err_type_msg):
+    num_problems=0
+    num_problems_peruncert = {}
+    if dict_key in js_dict: 
+      for mybin in js_dict[dict_key]:
+        probs=0;
+        num_problems+=len(js_dict[dict_key][mybin])
+        num_problems_peruncert[mybin]=len(js_dict[dict_key][mybin])
+      print ">>>INFO: there were ",num_problems," alerts of type ",err_type_msg
+      if args.printLevel > 1:
+        for mybin in js_dict[dict_key]:
+          print "    For bin",mybin, "there were ", num_problems_peruncert[mybin]," such alerts. The affected processes are: ", json.dumps(js_dict[dict_key][mybin])
+    else:
+      print ">>>There were no alerts of type", err_type_msg
+
+
 
 cb = ch.CombineHarvester()
 cb.SetFlag("check-negative-bins-on-import",0)
@@ -90,5 +106,6 @@ if args.printLevel > 0:
       print_uncertainty(data,"largeNormEff","\'Uncertainty has normalisation effect of more than %.1f%%\'"% (args.checkUncertOver*100))
       print_uncertainty(data,"smallShapeEff","\'Uncertainty probably has no genuine shape effect\'")
       print_process(data,"emptyProcessShape","\'Empty process\'")
+      print_process_info(data,"smallSignalProc","\'Small signal process\'")
 
 

--- a/CombineTools/scripts/ValidateDatacards.py
+++ b/CombineTools/scripts/ValidateDatacards.py
@@ -10,6 +10,9 @@ import argparse
 import json
 from pprint import pprint
 
+R.PyConfig.IgnoreCommandLineOptions = True
+R.gROOT.SetBatch(R.kTRUE)
+
 R.TH1.AddDirectory(False)
 
 parser = argparse.ArgumentParser()
@@ -17,18 +20,17 @@ parser = argparse.ArgumentParser()
 parser.add_argument('cards',
                     help='Specifies the full path to the datacards to check')
 parser.add_argument('--printLevel', '-p', default=1, type=int,
-                    help='Specify the level of info printing (0-3)')
+                    help='Specify the level of info printing (0-3, default:1)')
 parser.add_argument('--readOnly', action='store_true',
                     help='If this is enabled, skip validation and only read the output json')
 parser.add_argument('--checkUncertOver', '-c', default=0.1, type=float,
-                    help='Report uncertainties which have a normalisation effect larger than this fraction')
+                    help='Report uncertainties which have a normalisation effect larger than this fraction (default:0.1)')
 parser.add_argument('--reportSigUnder', '-s', default=0.001, type=float,
-                    help='Report signals contributing less than this fraction of the total in a channel')
+                    help='Report signals contributing less than this fraction of the total in a channel (default:0.001)')
 parser.add_argument('--jsonFile', default='validation.json',
-                    help='Path to the json file to read/write results from')
+                    help='Path to the json file to read/write results from (default:validation.json)')
 parser.add_argument('--mass', default='*',
-                    help='Signal mass to use')
-
+                    help='Signal mass to use (default:*)')
 
 args = parser.parse_args()
 

--- a/CombineTools/src/CombineHarvester_Python.cc
+++ b/CombineTools/src/CombineHarvester_Python.cc
@@ -178,6 +178,10 @@ void (*Overload1_CheckNormEff)(
 void (*Overload1_CheckSizeOfShapeEffect)(
     CombineHarvester&) = ch::CheckSizeOfShapeEffect;
 
+void (*Overload1_CheckSmallSignals)(
+    CombineHarvester&) = ch::CheckSmallSignals;
+
+
 // Use some macros for methods with default values
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(defaults_bin, bin, 1, 2)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(defaults_bin_id, bin_id, 1, 2)
@@ -501,6 +505,7 @@ BOOST_PYTHON_MODULE(libCombineHarvesterCombineTools)
     py::def("CheckEmptyShapes", Overload1_CheckEmptyShapes);
     py::def("CheckNormEff", Overload1_CheckNormEff);
     py::def("CheckSizeOfShapeEffect", Overload1_CheckSizeOfShapeEffect);
+    py::def("CheckSmallSignals", Overload1_CheckSmallSignals);
     py::def("ValidateCards", ch::ValidateCards);
 
 }

--- a/CombineTools/src/CombineHarvester_Python.cc
+++ b/CombineTools/src/CombineHarvester_Python.cc
@@ -169,8 +169,14 @@ void (Systematic::*Overload_Syst_set_shapes)(
 void (*Overload1_ValidateShapeUncertaintyDirection)(
     CombineHarvester&) = ch::ValidateShapeUncertaintyDirection;
 
+void (*Overload1_ValidateShapeTemplates)(
+    CombineHarvester&) = ch::ValidateShapeTemplates;
+
 void (*Overload1_CheckEmptyShapes)(
     CombineHarvester&) = ch::CheckEmptyShapes;
+
+void (*Overload1_CheckEmptyBins)(
+    CombineHarvester&) = ch::CheckEmptyBins;
 
 void (*Overload1_CheckNormEff)(
     CombineHarvester&, double) = ch::CheckNormEff;
@@ -179,7 +185,7 @@ void (*Overload1_CheckSizeOfShapeEffect)(
     CombineHarvester&) = ch::CheckSizeOfShapeEffect;
 
 void (*Overload1_CheckSmallSignals)(
-    CombineHarvester&) = ch::CheckSmallSignals;
+    CombineHarvester&, double) = ch::CheckSmallSignals;
 
 
 // Use some macros for methods with default values
@@ -502,7 +508,9 @@ BOOST_PYTHON_MODULE(libCombineHarvesterCombineTools)
     py::def("ParseCombineWorkspace", ch::ParseCombineWorkspacePy);
     py::def("PrintSystematic", ch::PrintSystematic);
     py::def("ValidateShapeUncertaintyDirection", Overload1_ValidateShapeUncertaintyDirection);
+    py::def("ValidateShapeTemplates", Overload1_ValidateShapeTemplates);
     py::def("CheckEmptyShapes", Overload1_CheckEmptyShapes);
+    py::def("CheckEmptyBins", Overload1_CheckEmptyBins);
     py::def("CheckNormEff", Overload1_CheckNormEff);
     py::def("CheckSizeOfShapeEffect", Overload1_CheckSizeOfShapeEffect);
     py::def("CheckSmallSignals", Overload1_CheckSmallSignals);

--- a/CombineTools/src/ValidationTools.cc
+++ b/CombineTools/src/ValidationTools.cc
@@ -176,10 +176,38 @@ void CheckSizeOfShapeEffect(CombineHarvester& cb, json& jsobj){
     }
   });
 }
-      
-    
+
+void CheckSmallSignals(CombineHarvester& cb){
+  auto bins = cb.bin_set();
+  for(auto b : bins){
+    auto cb_bin_signals = cb.cp().bin({b}).signals();
+    auto cb_bin_backgrounds = cb.cp().bin({b}).backgrounds();
+    auto cb_bin = cb.cp().bin({b}); 
+    double sigrate = cb_bin_signals.GetRate();
+    for(auto p : cb_bin_signals.process_set()){
+      if(cb_bin_signals.cp().process({p}).GetRate() < 0.001*sigrate){
+        std::cout<<"Very small signal process. In bin "<<b<<" signal process "<<p<<" has yield "<<cb_bin_signals.cp().process({p}).GetRate()<<". Total signal rate in this bin is "<<sigrate<<std::endl;
+      }
+    }
+  }
+}
 
 
+void CheckSmallSignals(CombineHarvester& cb, json& jsobj){
+  auto bins = cb.bin_set();
+  for(auto b : bins){
+    auto cb_bin_signals = cb.cp().bin({b}).signals();
+    auto cb_bin_backgrounds = cb.cp().bin({b}).backgrounds();
+    auto cb_bin = cb.cp().bin({b}); 
+    double sigrate = cb_bin_signals.GetRate();
+    for(auto p : cb_bin_signals.process_set()){
+      if(cb_bin_signals.cp().process({p}).GetRate() < 0.001*sigrate){
+        jsobj["smallSignalProc"][b][p]={{"sigrate_tot",sigrate},{"procrate",cb_bin_signals.cp().process({p}).GetRate()}};
+      }
+    }
+  }
+}
+  
 
 void ValidateCards(CombineHarvester& cb, std::string const& filename, double maxNormEff){
  json output_js; 
@@ -187,6 +215,7 @@ void ValidateCards(CombineHarvester& cb, std::string const& filename, double max
  CheckEmptyShapes(cb, output_js);      
  CheckNormEff(cb, maxNormEff, output_js);
  CheckSizeOfShapeEffect(cb, output_js);
+ CheckSmallSignals(cb,output_js);
  std::ofstream outfile(filename);
  outfile <<std::setw(4)<<output_js<<std::endl;
 }

--- a/CombineTools/src/ValidationTools.cc
+++ b/CombineTools/src/ValidationTools.cc
@@ -43,6 +43,49 @@ void ValidateShapeUncertaintyDirection(CombineHarvester& cb){
   });
 }
 
+void ValidateShapeTemplates(CombineHarvester& cb, json& jsobj){
+  cb.ForEachSyst([&](ch::Systematic *sys){
+  const TH1* hist_u;
+  const TH1* hist_d;
+  if(sys->type()=="shape" && ( fabs(sys->value_u() - sys->value_d()) < 0.0000001)){
+      hist_u = sys->shape_u();
+      hist_d = sys->shape_d();
+      bool is_same=1;
+      for(int i=1;i<=hist_u->GetNbinsX();i++){
+        if(fabs(hist_u->GetBinContent(i))+fabs(hist_d->GetBinContent(i))>0){
+          if(2*double(fabs(hist_u->GetBinContent(i)-hist_d->GetBinContent(i)))/(fabs(hist_u->GetBinContent(i))+fabs(hist_d->GetBinContent(i)))>0.001) is_same = 0;
+        }
+      }
+      if(is_same){
+        jsobj["uncertTemplSame"][sys->name()][sys->bin()][sys->process()]={{"value_u",sys->value_u()},{"value_d",sys->value_d()}};
+      }
+    }
+  });
+}
+
+void ValidateShapeTemplates(CombineHarvester& cb){
+  cb.ForEachSyst([&](ch::Systematic *sys){
+    const TH1* hist_u;
+    const TH1* hist_d;
+    if(sys->type()=="shape" && ( fabs(sys->value_u() - sys->value_d()) < 0.0000001)){
+      hist_u = sys->shape_u();
+      hist_d = sys->shape_d();
+      bool is_same=1;
+      for(int i=1;i<=hist_u->GetNbinsX();i++){
+        if(fabs(hist_u->GetBinContent(i))+fabs(hist_d->GetBinContent(i))>0){
+          if(2*double(fabs(hist_u->GetBinContent(i)-hist_d->GetBinContent(i)))/(fabs(hist_u->GetBinContent(i))+fabs(hist_d->GetBinContent(i)))>0.001) is_same = 0;
+        }
+      }
+      if(is_same){
+        PrintSystematic(sys);
+        std::cout<<"Up/Down templates are identical: up variation: "<<sys->value_u()<<", down variation: "<<sys->value_d()<<std::endl;
+      }
+    }
+  });
+}
+
+
+
 void CheckEmptyShapes(CombineHarvester& cb, json& jsobj){
   std::vector<ch::Process*> empty_procs;
   auto bins = cb.bin_set();
@@ -129,6 +172,39 @@ void CheckNormEff(CombineHarvester& cb, double maxNormEff, json& jsobj){
   });
 }
 
+void CheckEmptyBins(CombineHarvester& cb){
+  TH1F tothist;
+  auto bins = cb.bin_set();
+  for(auto b : bins){
+    auto cb_bin_backgrounds = cb.cp().bin({b}).backgrounds();
+    tothist = cb_bin_backgrounds.GetShape();
+    for(int i=1;i<=tothist.GetNbinsX();i++){
+      if(tothist.GetBinContent(i)<=0){ 
+        std::cout<<"Channel "<<b<<" bin "<<i<<" of the templates is empty in background"<<std::endl;
+      }
+    }
+  }
+}
+
+void CheckEmptyBins(CombineHarvester& cb, json& jsobj){
+  TH1F tothist;
+  auto bins = cb.bin_set();
+  for(auto b : bins){
+    auto cb_bin_backgrounds = cb.cp().bin({b}).backgrounds();
+    tothist = cb_bin_backgrounds.GetShape();
+    for(int i=1;i<=tothist.GetNbinsX();i++){
+      if(tothist.GetBinContent(i)<=0){ 
+        if (jsobj["emptyBkgBin"][b] !=NULL){
+          jsobj["emptyBkgBin"][b].push_back(i);
+        } else {
+          jsobj["emptyBkgBin"][b] = {i};
+        }
+      }
+    }
+  }
+}
+
+
 void CheckSizeOfShapeEffect(CombineHarvester& cb){
   double diff_lim=0.001;
   cb.ForEachSyst([&](ch::Systematic *sys){
@@ -143,8 +219,12 @@ void CheckSizeOfShapeEffect(CombineHarvester& cb){
       double up_diff=0;
       double down_diff=0;
       for(int i=1;i<=hist_u->GetNbinsX();i++){
-        up_diff+=2*double(fabs(hist_u->GetBinContent(i)-hist_nom.GetBinContent(i)))/(fabs(hist_u->GetBinContent(i))+fabs(hist_nom.GetBinContent(i)));
-        down_diff+=2*double(fabs(hist_d->GetBinContent(i)-hist_nom.GetBinContent(i)))/(fabs(hist_u->GetBinContent(i))+fabs(hist_nom.GetBinContent(i)));
+        if(fabs(hist_u->GetBinContent(i))+fabs(hist_nom.GetBinContent(i))>0){
+          up_diff+=2*double(fabs(hist_u->GetBinContent(i)-hist_nom.GetBinContent(i)))/(fabs(hist_u->GetBinContent(i))+fabs(hist_nom.GetBinContent(i)));
+        }
+        if(fabs(hist_d->GetBinContent(i))+fabs(hist_nom.GetBinContent(i))>0){
+          down_diff+=2*double(fabs(hist_d->GetBinContent(i)-hist_nom.GetBinContent(i)))/(fabs(hist_d->GetBinContent(i))+fabs(hist_nom.GetBinContent(i)));
+        }
       }
       if(up_diff<diff_lim && down_diff<diff_lim){
         PrintSystematic(sys);
@@ -169,15 +249,19 @@ void CheckSizeOfShapeEffect(CombineHarvester& cb, json& jsobj){
       double up_diff=0;
       double down_diff=0;
       for(int i=1;i<=hist_u->GetNbinsX();i++){
-        up_diff+=2*double(fabs(hist_u->GetBinContent(i)-hist_nom.GetBinContent(i)))/(fabs(hist_u->GetBinContent(i))+fabs(hist_nom.GetBinContent(i)));
-        down_diff+=2*double(fabs(hist_d->GetBinContent(i)-hist_nom.GetBinContent(i)))/(fabs(hist_u->GetBinContent(i))+fabs(hist_nom.GetBinContent(i)));
+        if(fabs(hist_u->GetBinContent(i))+fabs(hist_nom.GetBinContent(i))>0){
+          up_diff+=2*double(fabs(hist_u->GetBinContent(i)-hist_nom.GetBinContent(i)))/(fabs(hist_u->GetBinContent(i))+fabs(hist_nom.GetBinContent(i)));
+        }
+        if(fabs(hist_d->GetBinContent(i))+fabs(hist_nom.GetBinContent(i))>0){
+          down_diff+=2*double(fabs(hist_d->GetBinContent(i)-hist_nom.GetBinContent(i)))/(fabs(hist_d->GetBinContent(i))+fabs(hist_nom.GetBinContent(i)));
+        }
       }
       if(up_diff<diff_lim && down_diff<diff_lim) jsobj["smallShapeEff"][sys->name()][sys->bin()][sys->process()]={{"diff_u",up_diff},{"diff_d",down_diff}};
-    }
+    } 
   });
 }
 
-void CheckSmallSignals(CombineHarvester& cb){
+void CheckSmallSignals(CombineHarvester& cb,double minSigFrac){
   auto bins = cb.bin_set();
   for(auto b : bins){
     auto cb_bin_signals = cb.cp().bin({b}).signals();
@@ -185,7 +269,7 @@ void CheckSmallSignals(CombineHarvester& cb){
     auto cb_bin = cb.cp().bin({b}); 
     double sigrate = cb_bin_signals.GetRate();
     for(auto p : cb_bin_signals.process_set()){
-      if(cb_bin_signals.cp().process({p}).GetRate() < 0.001*sigrate){
+      if(cb_bin_signals.cp().process({p}).GetRate() < minSigFrac*sigrate){
         std::cout<<"Very small signal process. In bin "<<b<<" signal process "<<p<<" has yield "<<cb_bin_signals.cp().process({p}).GetRate()<<". Total signal rate in this bin is "<<sigrate<<std::endl;
       }
     }
@@ -193,7 +277,7 @@ void CheckSmallSignals(CombineHarvester& cb){
 }
 
 
-void CheckSmallSignals(CombineHarvester& cb, json& jsobj){
+void CheckSmallSignals(CombineHarvester& cb, double minSigFrac, json& jsobj){
   auto bins = cb.bin_set();
   for(auto b : bins){
     auto cb_bin_signals = cb.cp().bin({b}).signals();
@@ -201,7 +285,7 @@ void CheckSmallSignals(CombineHarvester& cb, json& jsobj){
     auto cb_bin = cb.cp().bin({b}); 
     double sigrate = cb_bin_signals.GetRate();
     for(auto p : cb_bin_signals.process_set()){
-      if(cb_bin_signals.cp().process({p}).GetRate() < 0.001*sigrate){
+      if(cb_bin_signals.cp().process({p}).GetRate() < minSigFrac*sigrate){
         jsobj["smallSignalProc"][b][p]={{"sigrate_tot",sigrate},{"procrate",cb_bin_signals.cp().process({p}).GetRate()}};
       }
     }
@@ -209,13 +293,25 @@ void CheckSmallSignals(CombineHarvester& cb, json& jsobj){
 }
   
 
-void ValidateCards(CombineHarvester& cb, std::string const& filename, double maxNormEff){
+void ValidateCards(CombineHarvester& cb, std::string const& filename, double maxNormEff, double minSigFrac){
  json output_js; 
- ValidateShapeUncertaintyDirection(cb, output_js);      
+ bool is_shape_card=1;
+ cb.ForEachProc([&](ch::Process *proc){
+   if(proc->pdf()||!(proc->shape())){
+     is_shape_card=0;
+    }
+ });
+ if(is_shape_card){     
+   ValidateShapeUncertaintyDirection(cb, output_js);      
+   CheckSizeOfShapeEffect(cb, output_js);
+   ValidateShapeTemplates(cb,output_js);
+ } else {
+   std::cout<<"Not a shape-based datacard / shape-based datacard using RooDataHist. Skipping checks on systematic shapes."<<std::endl;
+ }
  CheckEmptyShapes(cb, output_js);      
  CheckNormEff(cb, maxNormEff, output_js);
- CheckSizeOfShapeEffect(cb, output_js);
- CheckSmallSignals(cb,output_js);
+ CheckSmallSignals(cb,minSigFrac, output_js);
+ CheckEmptyBins(cb,output_js);
  std::ofstream outfile(filename);
  outfile <<std::setw(4)<<output_js<<std::endl;
 }

--- a/CombineTools/src/ValidationTools.cc
+++ b/CombineTools/src/ValidationTools.cc
@@ -305,13 +305,13 @@ void ValidateCards(CombineHarvester& cb, std::string const& filename, double max
    ValidateShapeUncertaintyDirection(cb, output_js);      
    CheckSizeOfShapeEffect(cb, output_js);
    ValidateShapeTemplates(cb,output_js);
+   CheckEmptyBins(cb,output_js);
  } else {
    std::cout<<"Not a shape-based datacard / shape-based datacard using RooDataHist. Skipping checks on systematic shapes."<<std::endl;
  }
  CheckEmptyShapes(cb, output_js);      
  CheckNormEff(cb, maxNormEff, output_js);
  CheckSmallSignals(cb,minSigFrac, output_js);
- CheckEmptyBins(cb,output_js);
  std::ofstream outfile(filename);
  outfile <<std::setw(4)<<output_js<<std::endl;
 }


### PR DESCRIPTION
Adds checks for
- Bins of a template that are empty in background
- Small signal processes 
- Up and down templates that are identical

Also only enables checks on shape-based templates/systematics *only* for TH1-shape-based analyses (Makes sure the tool doesn't crash on RooDataHist-based analyses)