### PR TITLE
MergeBinErrors fix on total bin error.

### DIFF
--- a/CombineTools/src/BinByBin.cc
+++ b/CombineTools/src/BinByBin.cc
@@ -77,7 +77,7 @@ void BinByBinFactory::MergeBinErrors(CombineHarvester &cb) {
       double removed = 0.0;
       for (unsigned r = 0; r < result.size(); ++r) {
         if ((std::get<0>(result[r]) + removed) < (merge_threshold * tot_bbb_added) &&
-            r < (result.size() - 1)) {
+            r < (result.size() - 1) && std::get<2>(result[r])) {
           bbb_removed += 1;
           removed += std::get<0>(result[r]);
           std::get<1>(result[r])->SetBinError(i, 0.0);


### PR DESCRIPTION
As shown in [these slides](https://github.com/cms-analysis/CombineHarvester/files/4230602/Torterotot_BBB_issue_in_combine-mini.pdf), the current bin error merging process is altering the total bin error. By adding a condition on can_expand for removing bin errors, there is no more total bin error altered by the merging process.

