### PR TITLE
handle setparameters for cats as well as vars

### DIFF
--- a/CombineTools/python/combine/utils.py
+++ b/CombineTools/python/combine/utils.py
@@ -56,9 +56,17 @@ def prefit_from_workspace(file, workspace, params, setPars=None):
     ROOT.RooMsgService.instance().setGlobalKillBelow(ROOT.RooFit.WARNING)
     if setPars is not None:
       parsToSet = [tuple(x.split('=')) for x in setPars.split(',')]
+      allParams = ws.allVars()
+      allParams.add(ws.allCats())
       for par, val in parsToSet:
-        print 'Setting paramter %s to %g' % (par, float(val))
-        ws.var(par).setVal(float(val))
+        tmp = allParams.find(par)
+        isrvar = tmp.IsA().InheritsFrom(ROOT.RooRealVar.Class())
+        if isrvar:
+          print 'Setting parameter %s to %g' % (par, float(val))
+          tmp.setVal(float(val))
+        else:
+          print 'Setting index %s to %g' % (par, float(val))
+          tmp.setIndex(int(val))
 
     for p in params:
         res[p] = {}


### PR DESCRIPTION
In Combine, it's possible to set the values of both variables and categories. CombineHarvester did not support setting values for categories, leading to inconsistency and potentially failed commands.

Here, I copied the logic from https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/blob/f2f442e3390e1fddabd042b6ef5ae62d4c1981d9/src/utils.cc#L713 to support setting category values.