### PR TITLE
Missing ws in missing shapes

### DIFF
--- a/CombineTools/src/CombineHarvester.cc
+++ b/CombineTools/src/CombineHarvester.cc
@@ -575,16 +575,17 @@ void CombineHarvester::LoadShapes(Systematic* entry,
   } else if (mapping.IsPdf()) {
     if (verbosity_ >= 2) LOGLINE(log(), "Mapping type is RooDataHist");
     // Try and get this as RooAbsData first. If this doesn't work try pdf
+    
     RooDataHist* h =
-        dynamic_cast<RooDataHist*>(mapping.sys_ws->data(mapping.WorkspaceObj().c_str()));
+        (mapping.sys_ws) ? dynamic_cast<RooDataHist*>(mapping.sys_ws->data(mapping.WorkspaceObj().c_str())) : nullptr;
     RooDataHist* h_u =
-        dynamic_cast<RooDataHist*>(mapping.sys_ws->data(p_s_hi.c_str()));
+        (mapping.sys_ws) ? dynamic_cast<RooDataHist*>(mapping.sys_ws->data(p_s_hi.c_str())): nullptr;
     RooDataHist* h_d =
-        dynamic_cast<RooDataHist*>(mapping.sys_ws->data(p_s_lo.c_str()));
-    RooAbsReal* pdf = mapping.sys_ws->function(mapping.WorkspaceObj().c_str());
-    RooAbsReal* pdf_u = mapping.sys_ws->function(p_s_hi.c_str());
-    RooAbsReal* pdf_d = mapping.sys_ws->function(p_s_lo.c_str());
-
+        (mapping.sys_ws) ? dynamic_cast<RooDataHist*>(mapping.sys_ws->data(p_s_lo.c_str())): nullptr;
+    RooAbsReal* pdf =   (mapping.sys_ws) ? mapping.sys_ws->function(mapping.WorkspaceObj().c_str()):nullptr;
+    RooAbsReal* pdf_u = (mapping.sys_ws) ? mapping.sys_ws->function(p_s_hi.c_str()):nullptr;
+    RooAbsReal* pdf_d = (mapping.sys_ws) ? mapping.sys_ws->function(p_s_lo.c_str()):nullptr;
+    
     if ((!h || !h_u || !h_d) && (!pdf || !pdf_u || !pdf_d)) {
       if (flags_.at("allow-missing-shapes")) {
         LOGLINE(log(), "Warning, shape missing:");


### PR DESCRIPTION
adding protection for syst_ws in case of missing shapes.

For line of type 'shape?' if the syst_ws is also missing (for any reason) the shapes retrieving fails. 
Add a protection that should preserve the logic. 

(Required to parse new hinv dc for hcomb) 