### PR TITLE
Rename systematics

### DIFF
--- a/CombineTools/interface/Systematic.h
+++ b/CombineTools/interface/Systematic.h
@@ -17,7 +17,7 @@ class Systematic : public Object {
   Systematic(Systematic&& other);
   Systematic& operator=(Systematic other);
 
-  void set_name(std::string const& name) { name_ = name; }
+  void set_name(std::string const& name);
   std::string const& name() const { return name_; }
 
   void set_type(std::string const& type) { type_ = type; }

--- a/CombineTools/src/CombineHarvester_Python.cc
+++ b/CombineTools/src/CombineHarvester_Python.cc
@@ -458,6 +458,7 @@ BOOST_PYTHON_MODULE(libCombineHarvesterCombineTools)
       // .def("set_name", &Systematic::set_name)
       .def("name", &Parameter::name,
           py::return_value_policy<py::copy_const_reference>())
+      .def("set_name", &Parameter::set_name)
       .def("set_val", &Parameter::set_val)
       .def("val", &Parameter::val)
       .def("set_err_u", &Parameter::set_err_u)

--- a/CombineTools/src/Systematic.cc
+++ b/CombineTools/src/Systematic.cc
@@ -2,6 +2,7 @@
 #include <iostream>
 #include "boost/format.hpp"
 #include "CombineHarvester/CombineTools/interface/Logging.h"
+#include <regex>
 
 namespace ch {
 
@@ -22,6 +23,15 @@ Systematic::Systematic()
   }
 
 Systematic::~Systematic() { }
+
+void Systematic::set_name(std::string const& name) { 
+//test = std::regex_replace(test, std::regex("def"), "klm");
+    if (data_u_) data_u_->SetName(std::regex_replace(data_u_->GetName(),std::regex(name_),name).c_str());
+    if (data_d_) data_d_->SetName(std::regex_replace(data_d_->GetName(),std::regex(name_),name).c_str());
+    if (pdf_u_) pdf_u_->SetName(std::regex_replace(pdf_u_->GetName(),std::regex(name_),name).c_str());
+    if (pdf_d_) pdf_d_->SetName(std::regex_replace(pdf_d_->GetName(),std::regex(name_),name).c_str());
+    name_ = name; 
+}
 
 void swap(Systematic& first, Systematic& second) {
   using std::swap;


### PR DESCRIPTION
shape systematics mapped to roofit objects in workspace (happening rarely) needs to be renamed accordingly.
using substitution of the syst_name in the object.

Not too resilient but effective for the time being;
in the future, it would be better to derive it from the mapping when writing, and setting it accordingly. 

Exporting set_name for param.

Needed for comb2021. 