### PR TITLE
Tool to gauge impact of individual parameters on process yields

### DIFF
--- a/CombineTools/interface/CombineHarvester.h
+++ b/CombineTools/interface/CombineHarvester.h
@@ -337,6 +337,7 @@ class CombineHarvester {
    */
   /**@{*/
   double GetRate();
+  std::map<std::string, double> RateEvolution(RooFitResult const& fit);
   double GetObservedRate();
   double GetUncertainty();
 

--- a/CombineTools/src/CombineHarvester_Python.cc
+++ b/CombineTools/src/CombineHarvester_Python.cc
@@ -232,6 +232,9 @@ BOOST_PYTHON_MODULE(libCombineHarvesterCombineTools)
   py::to_python_converter<std::map<std::string, CombineHarvester>,
                           convert_cpp_map_to_py_dict<std::string, CombineHarvester>>();
 
+  py::to_python_converter<std::map<std::string, double>,
+                          convert_cpp_map_to_py_dict<std::string, double>>();
+
   py::to_python_converter<TH1F,
                           convert_cpp_root_to_py_root<TH1F>>();
 
@@ -338,6 +341,7 @@ BOOST_PYTHON_MODULE(libCombineHarvesterCombineTools)
       // Modification
       .def("GetParameter", Overload1_GetParameter,
         py::return_value_policy<py::reference_existing_object>())
+      .def("RateEvolution", &CombineHarvester::RateEvolution)
       .def("UpdateParameters", Overload1_UpdateParameters)
       .def("RenameParameter", &CombineHarvester::RenameParameter)
       .def("RenameSystematic", &CombineHarvester::RenameSystematic)


### PR DESCRIPTION
This PR introduces a new function `RateEvolution` to the CombineHarvester. The function loops through the parameters in a given RooFitResults object and sets the respective parameter in the workspace to the post-fit value while leaving the other parameters at the pre-fit values. For each parameter, the yield of the processes is evaluated and stored in a map of the format

```c++
map[parname] = process_yield
```
where `parname` is the name of the parameter and `process_yield` is the yield of all processes in the harvester instance. The PR also adds the bindings for the python interface, where the map is accessible as a python dictionary.

This information can be used to gauge the impact of individual parameters on process yields. An example code snippet would be
```python
bins = harvester.bin_set()
for b in bins:
    bin_dict = {}
    for procs in process_list:
        proc_harvester = harvester.cp().bin([b]).process([procs])
        if len(proc_harvester.process_set()) == 0:
            print("Could not load processes '{}' for bin '{}'".format(procs, b))
            continue
        bin_dict[procs] = proc_harvester.RateEvolution(fit)
```
where `process_list` is the list of processes that are considered. The resulting nested dictionary can be used to create e.g. a 2D Histogram of the yield changes for the processes that are introduced by a given parameter, see this example: ![example](https://user-images.githubusercontent.com/26219567/149959740-7fba1b73-b08b-45e0-88df-6ac00ecdd182.png) This functionality helped to further analyze and understand the statistical model in the HIG-19-011 and might also be interesting for other analyses.