### PR TITLE
Added options in plotGof.py for custom range and bin numbers

### DIFF
--- a/CombineTools/python/plotting.py
+++ b/CombineTools/python/plotting.py
@@ -831,11 +831,14 @@ def treeToHist2D(t, x, y, name, cut, xmin, xmax, ymin, ymax, xbins, ybins):
     return h2d
 
 
-def makeHist1D(name, xbins, graph, scaleXrange=1.0):
+def makeHist1D(name, xbins, graph, scaleXrange=1.0, absoluteXrange=None):
     len_x = graph.GetX()[graph.GetN() - 1] - graph.GetX()[0]
     binw_x = (len_x * 0.5 / (float(xbins) - 1.)) - 1E-5
-    hist = R.TH1F(
-        name, '', xbins, graph.GetX()[0], scaleXrange * (graph.GetX()[graph.GetN() - 1] + binw_x))
+    if absoluteXrange:
+        hist = R.TH1F(name, '', xbins, absoluteXrange[0], absoluteXrange[1])
+    else:
+        hist = R.TH1F(
+            name, '', xbins, graph.GetX()[0], scaleXrange * (graph.GetX()[graph.GetN() - 1] + binw_x))
     return hist
 
 

--- a/CombineTools/scripts/plotGof.py
+++ b/CombineTools/scripts/plotGof.py
@@ -30,7 +30,7 @@ parser.add_argument(
     '--auto-style', nargs='?', const='', default=None, help="""Take line colors and styles from a pre-defined list""")
 parser.add_argument('--table_vals', help='Amount of values to be written in a table for different masses', default=10)
 parser.add_argument("--bins", default=100, type=int, help="Number of bins in histogram")
-parser.add_argument("--range", nargs=2, help="Range of histograms. Requires two arguments in the form of <min> <max>")
+parser.add_argument("--range", nargs=2, type=float, help="Range of histograms. Requires two arguments in the form of <min> <max>")
 args = parser.parse_args()
 
 

--- a/CombineTools/scripts/plotGof.py
+++ b/CombineTools/scripts/plotGof.py
@@ -29,6 +29,8 @@ parser.add_argument(
 parser.add_argument(
     '--auto-style', nargs='?', const='', default=None, help="""Take line colors and styles from a pre-defined list""")
 parser.add_argument('--table_vals', help='Amount of values to be written in a table for different masses', default=10)
+parser.add_argument("--bins", default=100, type=int, help="Number of bins in histogram")
+parser.add_argument("--range", nargs=2, help="Range of histograms. Requires two arguments in the form of <min> <max>")
 args = parser.parse_args()
 
 
@@ -104,7 +106,8 @@ if args.statistic in ["AD","KS"]:
         # if key not in titles:
         #     continue
         toy_graph = plot.ToyTGraphFromJSON(js, [args.mass,key,'toy'])
-        toy_hist = plot.makeHist1D("toys", 100, toy_graph, 1.15)
+        if args.range: toy_hist = plot.makeHist1D("toys", args.bins, toy_graph, 1.15, absoluteXrange=args.range)
+        else: toy_hist = plot.makeHist1D("toys", args.bins, toy_graph, 1.15)
         for i in range(toy_graph.GetN()):
             toy_hist.Fill(toy_graph.GetX()[i])
         pValue = js[args.mass][key]["p"]
@@ -177,7 +180,8 @@ else:
         js = json.load(jsfile)
     # graph_sets.append(plot.StandardLimitsFromJSONFile(file, args.show.split(',')))
     toy_graph = plot.ToyTGraphFromJSON(js, [args.mass, "toy"])
-    toy_hist = plot.makeHist1D("toys", 100, toy_graph)
+    if args.range: toy_hist = plot.makeHist1D("toys", args.bins, toy_graph, absoluteXrange=args.range)
+    else: toy_hist = plot.makeHist1D("toys", args.bins, toy_graph)
     for i in range(toy_graph.GetN()):
         toy_hist.Fill(toy_graph.GetX()[i])
     pValue = js[args.mass]["p"]


### PR DESCRIPTION
Hi,

I have added several options to plotGof.py to make plotting goodness-of-fit test statistics a bit more flexible. Previously when we plot with a JSON file containing all test statistic values, the script will plot a histogram with its range based on the highest and lowest value of the test statistic in that JSON file. This may cause problems when the JSON file contains an outlier.

For example, here is a goodness-of-fit plot with default options:
![gof_plot_default](https://user-images.githubusercontent.com/24592763/159122251-dbba86e5-d0bb-448b-90ca-a51836f8a6bc.png)

As you may not notice, there is a very small outlier bump around 4400, and this causes the whole distribution to be skewed sharply to the left.

I have added options `--range` and `--bins` allowing users to change histogram range and bins to better display the distribution of test statistics, regardless of outliers.

Here is the same distribution plotted with `--range` and `--bins` options applied:
![gof_plot_range](https://user-images.githubusercontent.com/24592763/159122383-d7da5585-497e-4b18-892b-513583fc82b6.png)
![gof_plot_rangeandbin](https://user-images.githubusercontent.com/24592763/159122404-ea92fe33-0fb8-4343-bd6b-014c5247e522.png)

The changes I am proposing would require changing the plotting functions in `CombineTools/python/plotting.py`, but it should not break existing code. Please let me know if you would like me to make any further changes.

Thanks,
Vichayanun