### PR TITLE
Added goodness-of-fit plot range auto adjustment based on gaussian fit

### DIFF
--- a/CombineTools/python/plotting.py
+++ b/CombineTools/python/plotting.py
@@ -831,11 +831,14 @@ def treeToHist2D(t, x, y, name, cut, xmin, xmax, ymin, ymax, xbins, ybins):
     return h2d
 
 
-def makeHist1D(name, xbins, graph, scaleXrange=1.0):
+def makeHist1D(name, xbins, graph, scaleXrange=1.0, absoluteXrange=None):
     len_x = graph.GetX()[graph.GetN() - 1] - graph.GetX()[0]
     binw_x = (len_x * 0.5 / (float(xbins) - 1.)) - 1E-5
-    hist = R.TH1F(
-        name, '', xbins, graph.GetX()[0], scaleXrange * (graph.GetX()[graph.GetN() - 1] + binw_x))
+    if absoluteXrange:
+        hist = R.TH1F(name, '', xbins, absoluteXrange[0], absoluteXrange[1])
+    else:
+        hist = R.TH1F(
+            name, '', xbins, graph.GetX()[0], scaleXrange * (graph.GetX()[graph.GetN() - 1] + binw_x))
     return hist
 
 

--- a/CombineTools/scripts/plotGof.py
+++ b/CombineTools/scripts/plotGof.py
@@ -205,8 +205,8 @@ else:
     for i in range(toy_graph.GetN()):
         toy_hist.Fill(toy_graph.GetX()[i])
     pValue = js[args.mass]["p"]
-    underflow_count = toy_hist.GetBinCount(0)
-    overflow_count = toy_hist.GetBinCount(args.bins+1)
+    underflow_count = toy_hist.GetBinContent(0)
+    overflow_count  = toy_hist.GetBinContent(args.bins+1)
     obs = plot.ToyTGraphFromJSON(js, [args.mass,"obs"])
     arr = ROOT.TArrow(obs.GetX()[0], 0.001, obs.GetX()[0], toy_hist.GetMaximum()/8, 0.02, "<|");
     # if axis is None:

--- a/CombineTools/scripts/plotGof.py
+++ b/CombineTools/scripts/plotGof.py
@@ -279,7 +279,7 @@ else:
         warningstrings = []
         if underflow_count != 0: warningstrings.append("%d underflow")
         if overflow_count != 0: warningstrings.append("%d overflow")
-        if (obs.GetX()[0] > args.range[1]) or (obs.GetX()[0] < args.range[0]): warningstrings.append("observed value not in range")
+        if (obs.GetX()[0] > toy_hist.GetBinLowEdge(args.bins+1)) or (obs.GetX()[0] < toy_hist.GetBinLowEdge(0)): warningstrings.append("observed value not in range")
         warningtext.AddText(', '.join(warningstrings))
         warningtext.Draw()
 

--- a/CombineTools/scripts/plotGof.py
+++ b/CombineTools/scripts/plotGof.py
@@ -30,7 +30,7 @@ parser.add_argument(
     '--auto-style', nargs='?', const='', default=None, help="""Take line colors and styles from a pre-defined list""")
 parser.add_argument('--table_vals', help='Amount of values to be written in a table for different masses', default=10)
 parser.add_argument("--bins", default=100, type=int, help="Number of bins in histogram")
-parser.add_argument("--range", nargs=2, help="Range of histograms. Requires two arguments in the form of <min> <max>")
+parser.add_argument("--range", nargs=2, type=float, help="Range of histograms. Requires two arguments in the form of <min> <max>")
 args = parser.parse_args()
 
 

--- a/CombineTools/scripts/plotGof.py
+++ b/CombineTools/scripts/plotGof.py
@@ -268,20 +268,41 @@ else:
     pvalue.AddText("p-value = %0.3f"%pValue)
     pvalue.Draw()
 
-    if (obs.GetX()[0] > toy_hist.GetBinLowEdge(args.bins+1)) or (obs.GetX()[0] < toy_hist.GetBinLowEdge(0)) or (underflow_count != 0) or (overflow_count != 0):
-        warningtext = ROOT.TPaveText(0.68, 0.78, 0.80, 0.82, "NDC")
-        warningtext.SetBorderSize(   0 )
-        warningtext.SetFillStyle (   0 )
-        warningtext.SetTextAlign (  32 )
-        warningtext.SetTextSize  (0.04 )
-        warningtext.SetTextColor (   2 )
-        warningtext.SetTextFont  (  62 )
+    arrow_not_in_range = (obs.GetX()[0] > toy_hist.GetBinLowEdge(args.bins+1)) or (obs.GetX()[0] < toy_hist.GetBinLowEdge(0))
+
+    warningtext1 = ROOT.TPaveText(0.68, 0.78, 0.80, 0.82, "NDC")
+    warningtext1.SetBorderSize(   0 )
+    warningtext1.SetFillStyle (   0 )
+    warningtext1.SetTextAlign (  32 )
+    warningtext1.SetTextSize  (0.04 )
+    warningtext1.SetTextColor (   2 )
+    warningtext1.SetTextFont  (  62 )
+
+    if  arrow_not_in_range and ((underflow_count != 0) or (overflow_count != 0)):
         warningstrings = []
-        if underflow_count != 0: warningstrings.append("%d underflow")
-        if overflow_count != 0: warningstrings.append("%d overflow")
-        if (obs.GetX()[0] > toy_hist.GetBinLowEdge(args.bins+1)) or (obs.GetX()[0] < toy_hist.GetBinLowEdge(0)): warningstrings.append("observed value not in range")
-        warningtext.AddText(', '.join(warningstrings))
-        warningtext.Draw()
+        if underflow_count != 0: warningstrings.append("%d underflow"%underflow_count)
+        if overflow_count != 0: warningstrings.append("%d overflow"%overflow_count)
+        warningtext1.AddText(', '.join(warningstrings))
+        warningtext1.Draw()
+
+        warningtext2 = ROOT.TPaveText(0.68, 0.73, 0.80, 0.77, "NDC")
+        warningtext2.SetBorderSize(   0 )
+        warningtext2.SetFillStyle (   0 )
+        warningtext2.SetTextAlign (  32 )
+        warningtext2.SetTextSize  (0.04 )
+        warningtext2.SetTextColor (   2 )
+        warningtext2.SetTextFont  (  62 )
+        warningtext2.AddText("observed value not in range")
+        warningtext2.Draw()
+    else:
+        if ((underflow_count != 0) or (overflow_count != 0)):
+            warningstrings = []
+            if underflow_count != 0: warningstrings.append("%d underflow"%underflow_count)
+            if overflow_count != 0: warningstrings.append("%d overflow"%overflow_count)
+            warningtext1.AddText(', '.join(warningstrings))
+        elif arrow_not_in_range:
+            warningtext1.AddText("observed value not in range")
+        warningtext1.Draw()
 
     canv.Print('.pdf')
     canv.Print('.png')

--- a/CombineTools/scripts/plotGof.py
+++ b/CombineTools/scripts/plotGof.py
@@ -109,6 +109,7 @@ if args.statistic in ["AD","KS"]:
         toy_graph = plot.ToyTGraphFromJSON(js, [args.mass,key,'toy'])
         if args.autogaus:
             toy_testgaus = plot.makeHist1D("toys_testgaus", args.bins, toy_graph, 1.15)
+            for i in range(toy_graph.GetN()): toy_testgaus.Fill(toy_graph.GetX()[i])
             gausfit_results = toy_testgaus.Fit("gaus", "SQ")
             automean = gausfit_results.Value(1)
             autostd  = gausfit_results.Value(2)
@@ -189,6 +190,7 @@ else:
     toy_graph = plot.ToyTGraphFromJSON(js, [args.mass, "toy"])
     if args.autogaus:
         toy_testgaus = plot.makeHist1D("toys_testgaus", args.bins, toy_graph)
+        for i in range(toy_graph.GetN()): toy_testgaus.Fill(toy_graph.GetX()[i])
         gausfit_results = toy_testgaus.Fit("gaus", "SQ")
         automean = gausfit_results.Value(1)
         autostd  = gausfit_results.Value(2)

--- a/CombineTools/scripts/plotGof.py
+++ b/CombineTools/scripts/plotGof.py
@@ -29,6 +29,8 @@ parser.add_argument(
 parser.add_argument(
     '--auto-style', nargs='?', const='', default=None, help="""Take line colors and styles from a pre-defined list""")
 parser.add_argument('--table_vals', help='Amount of values to be written in a table for different masses', default=10)
+parser.add_argument("--bins", default=100, type=int, help="Number of bins in histogram")
+parser.add_argument("--range", nargs=2, help="Range of histograms. Requires two arguments in the form of <min> <max>")
 args = parser.parse_args()
 
 
@@ -104,7 +106,8 @@ if args.statistic in ["AD","KS"]:
         # if key not in titles:
         #     continue
         toy_graph = plot.ToyTGraphFromJSON(js, [args.mass,key,'toy'])
-        toy_hist = plot.makeHist1D("toys", 100, toy_graph, 1.15)
+        if args.range: toy_hist = plot.makeHist1D("toys", args.bins, toy_graph, 1.15, absoluteXrange=args.range)
+        else: toy_hist = plot.makeHist1D("toys", args.bins, toy_graph, 1.15)
         for i in range(toy_graph.GetN()):
             toy_hist.Fill(toy_graph.GetX()[i])
         pValue = js[args.mass][key]["p"]
@@ -177,7 +180,8 @@ else:
         js = json.load(jsfile)
     # graph_sets.append(plot.StandardLimitsFromJSONFile(file, args.show.split(',')))
     toy_graph = plot.ToyTGraphFromJSON(js, [args.mass, "toy"])
-    toy_hist = plot.makeHist1D("toys", 100, toy_graph)
+    if args.range: toy_hist = plot.makeHist1D("toys", args.bins, toy_graph, absoluteXrange=args.range)
+    else: toy_hist = plot.makeHist1D("toys", args.bins, toy_graph)
     for i in range(toy_graph.GetN()):
         toy_hist.Fill(toy_graph.GetX()[i])
     pValue = js[args.mass]["p"]

--- a/CombineTools/scripts/plotGof.py
+++ b/CombineTools/scripts/plotGof.py
@@ -197,8 +197,8 @@ else:
     #    autostd  = gausfit_results.Value(2)
     #    toy_hist = plot.makeHist1D("toys", args.bins, toy_graph, absoluteXrange=(automean-3*autostd, automean+3*autostd))
     if args.percentile:
-        min_range = toy_graph.GetPointX(int(toy_graph.GetN()*args.percentile[0]))
-        max_range = toy_graph.GetPointX(int(toy_graph.GetN()*args.percentile[1]))
+        min_range = toy_graph.GetX()[int(toy_graph.GetN()*args.percentile[0])]
+        max_range = toy_graph.GetX()[int(toy_graph.GetN()*args.percentile[1])]
         toy_hist = plot.makeHist1D("toys", args.bins, toy_graph, absoluteXrange=(min_range, max_range))
     elif args.range: toy_hist = plot.makeHist1D("toys", args.bins, toy_graph, absoluteXrange=args.range)
     else: toy_hist = plot.makeHist1D("toys", args.bins, toy_graph)

--- a/CombineTools/scripts/plotGof.py
+++ b/CombineTools/scripts/plotGof.py
@@ -268,7 +268,7 @@ else:
     pvalue.AddText("p-value = %0.3f"%pValue)
     pvalue.Draw()
 
-    if ((obs.GetX()[0] > args.range[1]) or (obs.GetX()[0] < args.range[0])) or (underflow_count != 0) or (overflow_count != 0):
+    if (obs.GetX()[0] > toy_hist.GetBinLowEdge(args.bins+1)) or (obs.GetX()[0] < toy_hist.GetBinLowEdge(0)) or (underflow_count != 0) or (overflow_count != 0):
         warningtext = ROOT.TPaveText(0.68, 0.78, 0.80, 0.82, "NDC")
         warningtext.SetBorderSize(   0 )
         warningtext.SetFillStyle (   0 )

--- a/CombineTools/scripts/plotGof.py
+++ b/CombineTools/scripts/plotGof.py
@@ -31,7 +31,8 @@ parser.add_argument(
 parser.add_argument('--table_vals', help='Amount of values to be written in a table for different masses', default=10)
 parser.add_argument("--bins", default=100, type=int, help="Number of bins in histogram")
 parser.add_argument("--range", nargs=2, type=float, help="Range of histograms. Requires two arguments in the form of <min> <max>")
-parser.add_argument("--autogaus", action="store_true", help="Automatically adjust histogram range with gaussian fit. Overrides range option.")
+#parser.add_argument("--autogaus", action="store_true", help="Automatically adjust histogram range with gaussian fit. Overrides range option.")
+parser.add_argument("--percentile", nargs=2, type=float, help="Range of percentile from the distribution to be included. Requires two arguments in the form of <min> <max>. Overrides range option.")
 args = parser.parse_args()
 
 
@@ -188,18 +189,24 @@ else:
         js = json.load(jsfile)
     # graph_sets.append(plot.StandardLimitsFromJSONFile(file, args.show.split(',')))
     toy_graph = plot.ToyTGraphFromJSON(js, [args.mass, "toy"])
-    if args.autogaus:
-        toy_testgaus = plot.makeHist1D("toys_testgaus", args.bins, toy_graph)
-        for i in range(toy_graph.GetN()): toy_testgaus.Fill(toy_graph.GetX()[i])
-        gausfit_results = toy_testgaus.Fit("gaus", "SQ")
-        automean = gausfit_results.Value(1)
-        autostd  = gausfit_results.Value(2)
-        toy_hist = plot.makeHist1D("toys", args.bins, toy_graph, absoluteXrange=(automean-3*autostd, automean+3*autostd))
+    #if args.autogaus:
+    #    toy_testgaus = plot.makeHist1D("toys_testgaus", args.bins, toy_graph)
+    #    for i in range(toy_graph.GetN()): toy_testgaus.Fill(toy_graph.GetX()[i])
+    #    gausfit_results = toy_testgaus.Fit("gaus", "SQ")
+    #    automean = gausfit_results.Value(1)
+    #    autostd  = gausfit_results.Value(2)
+    #    toy_hist = plot.makeHist1D("toys", args.bins, toy_graph, absoluteXrange=(automean-3*autostd, automean+3*autostd))
+    if args.percentile:
+        min_range = toy_graph.GetPointX(int(toy_graph.GetN()*args.percentile[0]))
+        max_range = toy_graph.GetPointX(int(toy_graph.GetN()*args.percentile[1]))
+        toy_hist = plot.makeHist1D("toys", args.bins, toy_graph, absoluteXrange=(min_range, max_range))
     elif args.range: toy_hist = plot.makeHist1D("toys", args.bins, toy_graph, absoluteXrange=args.range)
     else: toy_hist = plot.makeHist1D("toys", args.bins, toy_graph)
     for i in range(toy_graph.GetN()):
         toy_hist.Fill(toy_graph.GetX()[i])
     pValue = js[args.mass]["p"]
+    underflow_count = toy_hist.GetBinCount(0)
+    overflow_count = toy_hist.GetBinCount(args.bins+1)
     obs = plot.ToyTGraphFromJSON(js, [args.mass,"obs"])
     arr = ROOT.TArrow(obs.GetX()[0], 0.001, obs.GetX()[0], toy_hist.GetMaximum()/8, 0.02, "<|");
     # if axis is None:
@@ -260,6 +267,21 @@ else:
     pvalue.SetTextFont  (  62 )
     pvalue.AddText("p-value = %0.3f"%pValue)
     pvalue.Draw()
+
+    if ((obs.GetX()[0] > args.range[1]) or (obs.GetX()[0] < args.range[0])) or (underflow_count != 0) or (overflow_count != 0):
+        warningtext = ROOT.TPaveText(0.68, 0.78, 0.80, 0.82, "NDC")
+        warningtext.SetBorderSize(   0 )
+        warningtext.SetFillStyle (   0 )
+        warningtext.SetTextAlign (  32 )
+        warningtext.SetTextSize  (0.04 )
+        warningtext.SetTextColor (   2 )
+        warningtext.SetTextFont  (  62 )
+        warningstrings = []
+        if underflow_count != 0: warningstrings.append("%d underflow")
+        if overflow_count != 0: warningstrings.append("%d overflow")
+        if (obs.GetX()[0] > args.range[1]) or (obs.GetX()[0] < args.range[0]): warningstrings.append("observed value not in range")
+        warningtext.AddText(', '.join(warningstrings))
+        warningtext.Draw()
 
     canv.Print('.pdf')
     canv.Print('.png')

--- a/CombineTools/scripts/plotGof.py
+++ b/CombineTools/scripts/plotGof.py
@@ -31,7 +31,7 @@ parser.add_argument(
 parser.add_argument('--table_vals', help='Amount of values to be written in a table for different masses', default=10)
 parser.add_argument("--bins", default=100, type=int, help="Number of bins in histogram")
 parser.add_argument("--range", nargs=2, type=float, help="Range of histograms. Requires two arguments in the form of <min> <max>")
-parser.add_argument("--autogaus", action="store_true", help="Automatically adjusts histogram ranges with gaussian fit. Overrides range options")
+parser.add_argument("--autogaus", action="store_true", help="Automatically adjust histogram range with gaussian fit. Overrides range option.")
 args = parser.parse_args()
 
 


### PR DESCRIPTION
Hi,

In addition to a pull request I made several hours ago https://github.com/cms-analysis/CombineHarvester/pull/270, I have also added another option **on top of that pull request** to automatically adjust the goodness-of-fit histogram range based on gaussian fit of the whole distribution of test statistics. The plot range covers from -3 s.d. to +3 s.d. as shown in the plot below.

![gof_plot_autogaus](https://user-images.githubusercontent.com/24592763/159131357-147aea09-bc0c-40a7-89db-77c0fe8b639b.png)

I am not sure if creating a pull request with changes on top of another pull request is a good practice, so please let me know if this is okay. Also please let me know if you would like me to add any other changes.

Thanks,
Vichayanun