### PR TITLE
Ensure datacard parsing does not crash when using autoMCStats and few processes

### DIFF
--- a/CombineTools/src/CombineHarvester_Datacards.cc
+++ b/CombineTools/src/CombineHarvester_Datacards.cc
@@ -432,7 +432,7 @@ int CombineHarvester::ParseDatacard(std::string const& filename,
       }
     }
 
-    if (start_nuisance_scan && words[i].size()-1 == words[r].size()) {
+    if (start_nuisance_scan && words[i].size()-1 == words[r].size() && !boost::iequals(words[i][1], "autoMCStats")) {
       for (unsigned p = 2; p < words[i].size(); ++p) {
         if (words[i][p] == "-") continue;
         auto sys = std::make_shared<Systematic>();


### PR DESCRIPTION
If only using a few processes, the number of words in the 'autoMCStats' line can be equal to the number of words in a normal systematics line, leading to a parsing error. This change checks that the second word of the line is not 'autoMCStats' before invoking the 'normal systematics' parsing loop. Fixes #273 