### PR TITLE
Add the mean yield calculation in post-fit sampling 

### DIFF
--- a/CombineTools/src/CombineHarvester_Evaluate.cc
+++ b/CombineTools/src/CombineHarvester_Evaluate.cc
@@ -136,10 +136,6 @@ TH1F CombineHarvester::GetShapeWithUncertainty(RooFitResult const& fit,
   TH1F shape = GetShapeInternal(lookup);
   TH1F yield_sum = GetShape();
 
-//  TTree sample_tree("sample_tree", "sample_tree");
-//  int bin_ind = 0; double yield = 0;
-//  sample_tree.Branch("bin_ind",&bin_ind);
-//  sample_tree.Branch("yield",&yield);
   std::map<int, std::vector<float>> sample_yields_perbin;    
   
   for (int i = 1; i <= shape.GetNbinsX(); ++i) {

--- a/CombineTools/src/CombineHarvester_Evaluate.cc
+++ b/CombineTools/src/CombineHarvester_Evaluate.cc
@@ -186,7 +186,7 @@ TH1F CombineHarvester::GetShapeWithUncertainty(RooFitResult const& fit,
   }
 
   for (int i = 1; i <= shape.GetNbinsX(); ++i) {
-      shape.SetBinError(i, std::sqrt(shape.GetBinError(i)/double(n_samples)));
+    shape.SetBinError(i, std::sqrt(shape.GetBinError(i)/double(n_samples)));
   }
   this->UpdateParameters(backup);
   return shape;

--- a/CombineTools/src/CombineHarvester_Evaluate.cc
+++ b/CombineTools/src/CombineHarvester_Evaluate.cc
@@ -182,7 +182,6 @@ TH1F CombineHarvester::GetShapeWithUncertainty(RooFitResult const& fit,
     }
     shape.SetBinError(i, std::sqrt(shape.GetBinError(i)/double(n_samples)));
   }
-
   this->UpdateParameters(backup);
   return shape;
 }


### PR DESCRIPTION
With this setup I can reproduce the post-fit uncertainties calculated with FitDiagnostics. 
Thought about doing the same but in one pass, i.e. calculate sum(y^2) and define err as mean(y^2) - (mean(y))^2, but it looks like especially with large numbers the calculation with two loops is more accurate. 