### PR TITLE
Update docs and scripts to v2.1.0

### DIFF
--- a/CombineTools/scripts/sparse-checkout-https.sh
+++ b/CombineTools/scripts/sparse-checkout-https.sh
@@ -10,6 +10,6 @@ else
   git init
   git remote add origin https://github.com/cms-analysis/CombineHarvester.git 
   git config core.sparsecheckout true; echo CombineTools/ >> .git/info/sparse-checkout
-  git pull origin v2.0.0
+  git pull origin v2.1.0
   popd
 fi

--- a/CombineTools/scripts/sparse-checkout-plotting-https.sh
+++ b/CombineTools/scripts/sparse-checkout-plotting-https.sh
@@ -10,6 +10,6 @@ else
   git init
   git remote add origin https://github.com/cms-analysis/CombineHarvester.git 
   git config core.sparsecheckout true; echo CombineTools/python >> .git/info/sparse-checkout
-  git pull origin v2.0.0
+  git pull origin v2.1.0
   popd
 fi

--- a/CombineTools/scripts/sparse-checkout-plotting-ssh.sh
+++ b/CombineTools/scripts/sparse-checkout-plotting-ssh.sh
@@ -10,6 +10,6 @@ else
   git init
   git remote add origin git@github.com:cms-analysis/CombineHarvester.git
   git config core.sparsecheckout true; echo CombineTools/python >> .git/info/sparse-checkout
-  git pull origin v2.0.0
+  git pull origin v2.1.0
   popd
 fi

--- a/CombineTools/scripts/sparse-checkout-ssh.sh
+++ b/CombineTools/scripts/sparse-checkout-ssh.sh
@@ -10,6 +10,6 @@ else
   git init
   git remote add origin git@github.com:cms-analysis/CombineHarvester.git
   git config core.sparsecheckout true; echo CombineTools/ >> .git/info/sparse-checkout
-  git pull origin v2.0.0
+  git pull origin v2.1.0
   popd
 fi

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Full documentation: http://cms-analysis.github.io/CombineHarvester
 
 ## Quick start
 
-This package requires HiggsAnalysis/CombinedLimit to be in your local CMSSW area. We follow the release recommendations of the combine developers which can be found [here](https://cms-analysis.github.io/HiggsAnalysis-CombinedLimit/#setting-up-the-environment-and-installation). The CombineHarvester framework is compatible with the CMSSW 10_2_X and 11_3_X series releases. The default branch, `main`, is for developments in the 11_3_X releases, and the current recommended tag is `v2.0.0`. The `102x` branch should be used in CMSSW_10_2_X, and is expected to receive only minor updates.
+This package requires HiggsAnalysis/CombinedLimit to be in your local CMSSW area. We follow the release recommendations of the combine developers which can be found [here](https://cms-analysis.github.io/HiggsAnalysis-CombinedLimit/#setting-up-the-environment-and-installation). The CombineHarvester framework is compatible with the CMSSW 10_2_X and 11_3_X series releases. The default branch, `main`, is for developments in the 11_3_X releases, and the current recommended tag is `v2.1.0`. The `102x` branch should be used in CMSSW_10_2_X, and is expected to receive only minor updates.
 
 If you just need the core CombineHarvester/CombineTools subpackage, then the following scripts can be used to clone the repository with a sparse checkout for this one only:
 
@@ -22,7 +22,7 @@ A new full release area can be set up and compiled in the following steps:
     git clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit
     # IMPORTANT: Checkout the recommended tag on the link above
     git clone https://github.com/cms-analysis/CombineHarvester.git CombineHarvester
-    git checkout v2.0.0
+    git checkout v2.1.0
     scram b
 
 Previously this package contained some analysis-specific subpackages. These packages can now be found [here](https://gitlab.cern.ch/cms-hcg/ch-areas). If you would like a repository for your analysis package to be created in that group, please create an issue in the CombineHarvester repository stating the desired package name and your NICE username. Note: you are not obliged to store your analysis package in this central group.

--- a/docs/Main.md
+++ b/docs/Main.md
@@ -40,7 +40,7 @@ The CMSSW version that should be used with CombineHarvester is driven by the rec
     git clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit
     # IMPORTANT: Checkout the recommended tag on the link above
     git clone https://github.com/cms-analysis/CombineHarvester.git CombineHarvester
-    git checkout v2.0.0
+    git checkout v2.1.0
     scram b
 
 If you are using this framework for the first time we recommend taking a look through some of the examples below which demonstrate the main features:


### PR DESCRIPTION
The docs are still pointing to v2.0.0 while v2.1.0 is now the recommended tag.