### PR TITLE
Add the variables for param NP to the datacard parsing and writing methods

### DIFF
--- a/CombineTools/interface/CombineHarvester.h
+++ b/CombineTools/interface/CombineHarvester.h
@@ -406,7 +406,7 @@ class CombineHarvester {
                     std::vector<std::string> channel,
                     std::vector<std::string> procs,
                     ch::Categories bin, bool signal);
-
+  void AddSystVar(std::string const& name, double val, double err);
   void AddSystFromProc(Process const& proc, std::string const& name,
                        std::string const& type, bool asymm, double val_u,
                        double val_d, std::string const& formula,

--- a/CombineTools/src/CombineHarvester_Creation.cc
+++ b/CombineTools/src/CombineHarvester_Creation.cc
@@ -134,6 +134,20 @@ void CombineHarvester::AddSystFromProc(Process const& proc,
   systs_.push_back(sys);
 }
 
+void CombineHarvester::AddSystVar(std::string const& name,
+                                       std::string const& type,
+                                       double val, double err) {
+  auto sys = std::make_shared<Systematic>();
+  sys->set_name(subbed_name);
+  sys->set_type(type);
+  sys->set_value_u(val);
+  sys->set_value_d(val);
+  sys->set_err_d(err);
+  sys->set_err_d(err);
+  SetupRateParamVar(name, val);
+  systs_.push_back(sys);
+}
+
 void CombineHarvester::RenameSystematic(CombineHarvester &target, std::string const& old_name,
                                         std::string const& new_name) {
  for(unsigned i = 0; i<systs_.size(); ++i){

--- a/CombineTools/src/CombineHarvester_Creation.cc
+++ b/CombineTools/src/CombineHarvester_Creation.cc
@@ -135,16 +135,14 @@ void CombineHarvester::AddSystFromProc(Process const& proc,
 }
 
 void CombineHarvester::AddSystVar(std::string const& name,
-                                       std::string const& type,
-                                       double val, double err) {
+                                  double val, double err) {
+  Parameter * param = SetupRateParamVar(name,val);
+  param->set_val(val);
+  param->set_err_u(+1.0 *err);
+  param->set_err_d(-1.0 *err);
   auto sys = std::make_shared<Systematic>();
-  sys->set_name(subbed_name);
-  sys->set_type(type);
-  sys->set_value_u(val);
-  sys->set_value_d(val);
-  sys->set_err_d(err);
-  sys->set_err_d(err);
-  SetupRateParamVar(name, val);
+  sys->set_name(name);
+  sys->set_type("param");
   systs_.push_back(sys);
 }
 


### PR DESCRIPTION
At the moment CH is not able to parse and write the `param` nuisances to the datacards, attempting to fix it. 
Also included the `param` variables to the `rateParam` workspaces so that the rate parameter formulas with the `param` nuisances as arguments could be compiled. 