### PR TITLE
Add new method for extArg import to reduce memory consumption

### DIFF
--- a/CombineTools/interface/CombineHarvester.h
+++ b/CombineTools/interface/CombineHarvester.h
@@ -544,6 +544,7 @@ class CombineHarvester {
   void SetupRateParamFunc(std::string const& name, std::string const& formula,
                           std::string const& pars);
   void SetupRateParamWspObj(std::string const& name, std::string const& obj, bool is_ext_arg = false);
+  bool SetupRateParamWspObjFromWsStore(std::string const& name, std::string const& obj,                                                                                               std::map<std::string, std::shared_ptr<RooWorkspace>> const& ws_store);
   // ---------------------------------------------------------------
   // Private methods for the shape writing routines
   // ---------------------------------------------------------------

--- a/CombineTools/src/CombineHarvester_Datacards.cc
+++ b/CombineTools/src/CombineHarvester_Datacards.cc
@@ -197,7 +197,9 @@ int CombineHarvester::ParseDatacard(std::string const& filename,
           }
         }
       } else if (words[i].size() == 3 && is_wsp_rateparam) {
-        SetupRateParamWspObj(param_name, words[i][2], true);
+          if (!SetupRateParamWspObjFromWsStore(param_name, words[i][2], ws_store)) {
+            SetupRateParamWspObj(param_name, words[i][2], true);
+          }
       }
     }
   }


### PR DESCRIPTION
When parsing large models where the `extArg` parameters are imported multiple times with [RooWorkspace::import](https://root.cern.ch/doc/v622/classRooWorkspace.html#aa24d82e45a247162b161daa640d48998) the process gets killed due to the large memory consumption. 

This PR tries to avoid using this method if the pointer to the workspace is already created. Also this fix might not be relevant after with ROOT version>= 6.28 since it looks like the TFile is created with std::unique_ptr see [here](https://root.cern.ch/doc/v628/classRooWorkspace.html#a48ad73e289c3317e48d2efc29facbd08) 