### PR TITLE
Correct counting of toys for F-C in LimitGrid.py

### DIFF
--- a/CombineTools/python/combine/LimitGrids.py
+++ b/CombineTools/python/combine/LimitGrids.py
@@ -223,7 +223,11 @@ class HybridNewGrid(CombineToolBase):
 
         if hyp_res is not None:
             # We will take the number of toys thrown as the minimum of the number of b-only or s+b toys
-            ntoys = min(hyp_res.GetNullDistribution().GetSize(), hyp_res.GetAltDistribution().GetSize())
+            if feldman_cousins:
+                # For F-C we expect only s+b toys
+                ntoys = hyp_res.GetAltDistribution().GetSize()
+            else:
+                ntoys = min(hyp_res.GetNullDistribution().GetSize(), hyp_res.GetAltDistribution().GetSize())
             print('>>> Number of b toys %i' %(hyp_res.GetNullDistribution().GetSize()))
             print('>>> Number of s+b toys %i'%(hyp_res.GetAltDistribution().GetSize()))
 


### PR DESCRIPTION
When counting number of completed toys, should count only number of s+b toys when doing Feldman-Cousins (current behaviour was min(b-only, s+b).