### PR TITLE
ROOT v6.30: Update RooWorkspace::Clone 

### DIFF
--- a/CombineTools/src/CombineHarvester.cc
+++ b/CombineTools/src/CombineHarvester.cc
@@ -682,7 +682,7 @@ std::shared_ptr<RooWorkspace> CombineHarvester::SetupWorkspace(
     // bugs
     if (GetFlag("workspaces-use-clone")) {
       wspaces_[std::string(ws.GetName())] = std::shared_ptr<RooWorkspace>(
-              reinterpret_cast<RooWorkspace*>(ws.Clone())
+              reinterpret_cast<RooWorkspace*>(ws.Clone(ws.GetName()))
           );      
     } else {
       wspaces_[std::string(ws.GetName())] =


### PR DESCRIPTION
to account for the update [here](https://github.com/root-project/root/commit/ad275f1dc00c433a9e31f4936d249bfbb9e87270 ), in which RooWorkspace::Clone got overridden in ROOT v6.30, previously was inherited from TObject 