### PR TITLE
change ValidateDatacards report for 1-bin shapes

### DIFF
--- a/CombineTools/scripts/ValidateDatacards.py
+++ b/CombineTools/scripts/ValidateDatacards.py
@@ -130,5 +130,6 @@ if args.printLevel > 0:
             print_process(data,"emptyProcessShape","\'Empty process\'")
             print_bin(data,"emptyBkgBin","\'Bins of the template empty in background\'")
             print_process_info(data,"smallSignalProc","\'Small signal process\'")
+            print_process_info(data,"smallShapeEff1bin","\'Shape uncertainties with 1 bin only. You can consider replacing them with lnN\'")
 
 

--- a/CombineTools/src/ValidationTools.cc
+++ b/CombineTools/src/ValidationTools.cc
@@ -244,7 +244,7 @@ void CheckSizeOfShapeEffect(CombineHarvester& cb, json& jsobj){
     if(sys->type()=="shape"){
       hist_u = sys->shape_u();
       hist_d = sys->shape_d();
-      if (hist_u->GetNbinsX() = 1) jsobj["smallShapeEff1bin"][sys->name()][sys->bin()][sys->process()]={{"diff_u",up_diff},{"diff_d",down_diff}};
+      if (hist_u->GetNbinsX() == 1) jsobj["smallShapeEff1bin"][sys->name()][sys->bin()][sys->process()]={{"diff_u",up_diff},{"diff_d",down_diff}};
       else{
         hist_nom=cb.cp().bin({sys->bin()}).process({sys->process()}).GetShape();
         hist_nom.Scale(1./hist_nom.Integral());


### PR DESCRIPTION
See issue #331  for more details. Moved reporting of small shape effect from warning to info in case of shapes with a single bin.