### PR TITLE
Add "nuisance edit freeze" for extArgs declared as frozen in CH

### DIFF
--- a/CombineTools/src/CombineHarvester_Datacards.cc
+++ b/CombineTools/src/CombineHarvester_Datacards.cc
@@ -1222,9 +1222,7 @@ void CombineHarvester::WriteDatacard(std::string const& name,
       }
     }
   }
-  for (auto const& par : frozen_params) {
-    txt_file << "nuisance edit freeze " << par << "\n";
-  }
+
   std::set<std::string> all_fn_param_args;
   for (auto const& rp : floating_params) {
     if (!params_.count(rp[0])) {
@@ -1292,6 +1290,9 @@ void CombineHarvester::WriteDatacard(std::string const& name,
             txt_file << format(" [%.4g,%.4g]") % p->range_d() % p->range_u();
           }
           txt_file << "\n";
+          if (p->frozen()) {
+            frozen_params.insert(p->name());
+          }
         }
 
       }
@@ -1308,6 +1309,10 @@ void CombineHarvester::WriteDatacard(std::string const& name,
 
       }
     }
+  }
+
+  for (auto const& par : frozen_params) {
+    txt_file << "nuisance edit freeze " << par << "\n";
   }
 
   std::set<std::string> ws_vars;


### PR DESCRIPTION
Currently, an extArg parameter declared by the user can be set as frozen, but this is not respected when writing the datacard, e.g.:

```py
    cb.AddExtArgValue("my_param", 10.)
    cb.GetParameter("my_param").set_frozen(True)
```

has no effect. With this fix, we keep track of frozen extArgs and write the appropriate "nuisance edit freeze" line. 