### PR TITLE
Fix compilation warning for loop variable type

### DIFF
--- a/CombinePdfs/bin/SMLegacyMorphing.cpp
+++ b/CombinePdfs/bin/SMLegacyMorphing.cpp
@@ -108,8 +108,8 @@ int main() {
   vector<string> masses = ch::ValsFromRange("110:145|5");
 
   cout << ">> Creating processes and observations...\n";
-  for (string era : {"7TeV", "8TeV"}) {
-    for (auto chn : chns) {
+  for (const string era : {"7TeV", "8TeV"}) {
+    for (const auto& chn : chns) {
       cb.AddObservations(
         {"*"}, {"htt"}, {era}, {chn}, cats[chn+"_"+era]);
       cb.AddProcesses(
@@ -130,8 +130,8 @@ int main() {
   ch::AddSystematics_tt(cb);
 
   cout << ">> Extracting histograms from input root files...\n";
-  for (string era : {"7TeV", "8TeV"}) {
-    for (string chn : chns) {
+  for (const string era : {"7TeV", "8TeV"}) {
+    for (const string& chn : chns) {
       // Skip 7TeV tt:
       if (chn == "tt" && era == "7TeV") continue;
       string file = aux_shapes + input_folders[chn] + "/htt_" + chn +
@@ -148,8 +148,8 @@ int main() {
   map<string, TGraph> xs;
   // Get the table of H->tau tau BRs vs mass
   xs["htt"] = ch::TGraphFromTable(input_dir+"/xsecs_brs/htt_YR3.txt", "mH", "br");
-  for (string const& e : {"7TeV", "8TeV"}) {
-    for (string const& p : sig_procs) {
+  for (const string e : {"7TeV", "8TeV"}) {
+    for (const string& p : sig_procs) {
       // Get the table of xsecs vs mass for process "p" and era "e":
       xs[p+"_"+e] = ch::TGraphFromTable(input_dir+"/xsecs_brs/"+p+"_"+e+"_YR3.txt", "mH", "xsec");
       cout << ">>>> Scaling for process " << p << " and era " << e << "\n";
@@ -160,8 +160,8 @@ int main() {
     }
   }
   xs["hww_over_htt"] = ch::TGraphFromTable(input_dir+"/xsecs_brs/hww_over_htt.txt", "mH", "ratio");
-  for (string const& e : {"7TeV", "8TeV"}) {
-    for (string const& p : {"ggH", "qqH"}) {
+  for (const string e : {"7TeV", "8TeV"}) {
+    for (const string p : {"ggH", "qqH"}) {
      cb.cp().channel({"em"}).process({p+"_hww125"}).era({e})
        .ForEachProc([&](ch::Process *proc) {
          proc->set_rate(proc->rate() * xs[p+"_"+e].Eval(125.) * xs["htt"].Eval(125.));

--- a/CombineTools/bin/SMLegacyExample.cpp
+++ b/CombineTools/bin/SMLegacyExample.cpp
@@ -99,7 +99,7 @@ int main() {
   vector<string> masses = ch::ValsFromRange("110:145|5");
 
   cout << ">> Creating processes and observations...\n";
-  for (string era : {"7TeV", "8TeV"}) {
+  for (const string era : {"7TeV", "8TeV"}) {
     for (auto chn : chns) {
       cb.AddObservations(
         {"*"}, {"htt"}, {era}, {chn}, cats[chn+"_"+era]);
@@ -121,8 +121,8 @@ int main() {
   ch::AddSystematics_tt(cb);
 
   cout << ">> Extracting histograms from input root files...\n";
-  for (string era : {"7TeV", "8TeV"}) {
-    for (string chn : chns) {
+  for (const string era : {"7TeV", "8TeV"}) {
+    for (const string& chn : chns) {
       // Skip 7TeV tt:
       if (chn == "tt" && era == "7TeV") continue;
       string file = aux_shapes + input_folders[chn] + "/htt_" + chn +
@@ -139,8 +139,8 @@ int main() {
   map<string, TGraph> xs;
   // Get the table of H->tau tau BRs vs mass
   xs["htt"] = ch::TGraphFromTable(input_dir+"/xsecs_brs/htt_YR3.txt", "mH", "br");
-  for (string const& e : {"7TeV", "8TeV"}) {
-    for (string const& p : sig_procs) {
+  for (const string e : {"7TeV", "8TeV"}) {
+    for (const string& p : sig_procs) {
       // Get the table of xsecs vs mass for process "p" and era "e":
       xs[p+"_"+e] = ch::TGraphFromTable(input_dir+"/xsecs_brs/"+p+"_"+e+"_YR3.txt", "mH", "xsec");
       cout << ">>>> Scaling for process " << p << " and era " << e << "\n";
@@ -152,8 +152,8 @@ int main() {
   }
   //! [part1]
   xs["hww_over_htt"] = ch::TGraphFromTable(input_dir+"/xsecs_brs/hww_over_htt.txt", "mH", "ratio");
-  for (string const& e : {"7TeV", "8TeV"}) {
-    for (string const& p : {"ggH", "qqH"}) {
+  for (const string e : {"7TeV", "8TeV"}) {
+    for (const string p : {"ggH", "qqH"}) {
      cb.cp().channel({"em"}).process({p+"_hww125"}).era({e})
        .ForEachProc([&](ch::Process *proc) {
          proc->set_rate(proc->rate() * xs[p+"_"+e].Eval(125.) * xs["htt"].Eval(125.));

--- a/CombineTools/interface/strict_fstream.hpp
+++ b/CombineTools/interface/strict_fstream.hpp
@@ -125,7 +125,7 @@ struct static_method_holder
             is_p->peek();
             peek_failed = is_p->fail();
         }
-        catch (std::ios_base::failure e) {}
+        catch (const std::ios_base::failure& e) {}
         if (peek_failed)
         {
             throw Exception(std::string("strict_fstream: open('")

--- a/CombineTools/src/CombineHarvester_Creation.cc
+++ b/CombineTools/src/CombineHarvester_Creation.cc
@@ -89,7 +89,7 @@ void CombineHarvester::AddSystFromProc(Process const& proc,
   boost::replace_all(subbed_name, "$CHANNEL", proc.channel());
   boost::replace_all(subbed_name, "$ANALYSIS", proc.analysis());
   std::map<std::string,std::string> attrs = proc.all_attributes();
-  for( const auto it : attrs){
+  for( const auto& it : attrs){
       boost::replace_all(subbed_name, "$ATTR("+it.first+")",proc.attribute(it.first));
   }
   auto sys = std::make_shared<Systematic>();
@@ -121,7 +121,7 @@ void CombineHarvester::AddSystFromProc(Process const& proc,
       boost::replace_all(subbed_args, "$ERA", proc.era());
       boost::replace_all(subbed_args, "$CHANNEL", proc.channel());
       boost::replace_all(subbed_args, "$ANALYSIS", proc.analysis());
-      for( const auto it : attrs){
+      for( const auto& it : attrs){
           boost::replace_all(subbed_args, "$ATTR("+it.first+")",proc.attribute(it.first));
       }
       SetupRateParamFunc(subbed_name, formula, subbed_args);


### PR DESCRIPTION
Some simple fixes to remove these harmless, but annoying compilation warnings:
```cpp
$ scramv1 b clean; scramv1 b -j$(nproc --ignore=2)

...

>> Compiling  src/CombineHarvester/CombineTools/src/CombineHarvester_Creation.cc
>> Compiling  src/CombineHarvester/CombineTools/src/CardWriter.cc
>> Compiling  src/CombineHarvester/CombineTools/src/CombineHarvester_Datacards.cc
>> Compiling  src/CombineHarvester/CombineTools/src/CombineHarvester_Evaluate.cc
>> Compiling  src/CombineHarvester/CombineTools/src/CombineHarvester_Filters.cc
>> Compiling  src/CombineHarvester/CombineTools/src/CopyTools.cc
>> Compiling  src/CombineHarvester/CombineTools/src/HhhSystematics.cc
src/CombineHarvester/CombineTools/src/CombineHarvester_Creation.cc: In member function 'void ch::CombineHarvester::AddSystFromProc(const ch::Process&, const std::string&, const std::string&, bool, double, double, const std::string&, const std::string&)':
src/CombineHarvester/CombineTools/src/CombineHarvester_Creation.cc:92:19: warning: loop variable 'it' creates a copy from type 'const std::pair<const std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >' [-Wrange-loop-construct]
   92 |   for( const auto it : attrs){
      |                   ^~
src/CombineHarvester/CombineTools/src/CombineHarvester_Creation.cc:92:19: note: use reference type to prevent copying
   92 |   for( const auto it : attrs){
      |                   ^~
      |                   &
src/CombineHarvester/CombineTools/src/CombineHarvester_Creation.cc:124:23: warning: loop variable 'it' creates a copy from type 'const std::pair<const std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >' [-Wrange-loop-construct]
  124 |       for( const auto it : attrs){
      |                       ^~
src/CombineHarvester/CombineTools/src/CombineHarvester_Creation.cc:124:23: note: use reference type to prevent copying
  124 |       for( const auto it : attrs){
      |                       ^~
      |                       &
>> Compiling  src/CombineHarvester/CombineTools/src/HistMapping.cc
In file included from src/CombineHarvester/CombineTools/interface/zstr.hpp:16,
                 from src/CombineHarvester/CombineTools/src/CombineHarvester_Datacards.cc:32:
src/CombineHarvester/CombineTools/interface/strict_fstream.hpp: In static member function 'static void strict_fstream::detail::static_method_holder::check_peek(std::istream*, const std::string&, std::ios_base::openmode)':
src/CombineHarvester/CombineTools/interface/strict_fstream.hpp:128:39: warning: catching polymorphic type 'class std::ios_base::failure' by value [-Wcatch-value=]
  128 |         catch (std::ios_base::failure e) {}
      |                                       ^

...

>> Compiling  src/CombineHarvester/CombinePdfs/bin/SMLegacyMorphing.cpp
>> Compiling  src/CombineHarvester/CombineTools/bin/Example1.cpp
>> Compiling  src/CombineHarvester/CombineTools/bin/Example2.cpp
>> Compiling  src/CombineHarvester/CombineTools/bin/Example3.cpp
>> Compiling  src/CombineHarvester/CombineTools/bin/GamGamExample.cpp
>> Compiling  src/CombineHarvester/CombineTools/bin/ImpactsTable.cpp
>> Compiling  src/CombineHarvester/CombineTools/bin/LimitCompare.cpp
>> Compiling  src/CombineHarvester/CombineTools/bin/MSSMExample.cpp
In file included from /cvmfs/cms.cern.ch/el9_amd64_gcc12/external/boost/1.80.0-87b5de10acd2f2c8a325345ad058b814/include/boost/bind.hpp:30,
                 from src/CombineHarvester/CombinePdfs/bin/ParametricMSSM.cpp:5:
/cvmfs/cms.cern.ch/el9_amd64_gcc12/external/boost/1.80.0-87b5de10acd2f2c8a325345ad058b814/include/boost/bind.hpp:36:1: note: '#pragma message: The practice of declaring the Bind placeholders (_1, _2, ...) in the global namespace is deprecated. Please use <boost/bind/bind.hpp> + using namespace boost::placeholders, or define BOOST_BIND_GLOBAL_PLACEHOLDERS to retain the current behavior.'
   36 | BOOST_PRAGMA_MESSAGE(
      | ^~~~~~~~~~~~~~~~~~~~
>> Compiling  src/CombineHarvester/CombineTools/bin/MSSMUpdate.cpp
src/CombineHarvester/CombinePdfs/bin/SMLegacyMorphing.cpp: In function 'int main()':
src/CombineHarvester/CombinePdfs/bin/SMLegacyMorphing.cpp:151:22: warning: loop variable 'e' of type 'const std::string&' {aka 'const std::__cxx11::basic_string<char>&'} binds to a temporary constructed from type 'const char* const' [-Wrange-loop-construct]
  151 |   for (string const& e : {"7TeV", "8TeV"}) {
      |                      ^
src/CombineHarvester/CombinePdfs/bin/SMLegacyMorphing.cpp:151:22: note: use non-reference type 'const std::string' {aka 'const std::__cxx11::basic_string<char>'} to make the copy explicit or 'const char* const&' to prevent copying
src/CombineHarvester/CombinePdfs/bin/SMLegacyMorphing.cpp:163:22: warning: loop variable 'e' of type 'const std::string&' {aka 'const std::__cxx11::basic_string<char>&'} binds to a temporary constructed from type 'const char* const' [-Wrange-loop-construct]
  163 |   for (string const& e : {"7TeV", "8TeV"}) {
      |                      ^
src/CombineHarvester/CombinePdfs/bin/SMLegacyMorphing.cpp:163:22: note: use non-reference type 'const std::string' {aka 'const std::__cxx11::basic_string<char>'} to make the copy explicit or 'const char* const&' to prevent copying
src/CombineHarvester/CombinePdfs/bin/SMLegacyMorphing.cpp:164:24: warning: loop variable 'p' of type 'const std::string&' {aka 'const std::__cxx11::basic_string<char>&'} binds to a temporary constructed from type 'const char* const' [-Wrange-loop-construct]
  164 |     for (string const& p : {"ggH", "qqH"}) {
      |                        ^
src/CombineHarvester/CombinePdfs/bin/SMLegacyMorphing.cpp:164:24: note: use non-reference type 'const std::string' {aka 'const std::__cxx11::basic_string<char>'} to make the copy explicit or 'const char* const&' to prevent copying

...

>> Compiling  src/CombineHarvester/CombineTools/bin/SMLegacyExample.cpp
>> Compiling  src/CombineHarvester/CombineTools/bin/SOBPlot.cpp
>> Compiling  src/CombineHarvester/CombineTools/bin/ValidateDatacard.cpp
>> Compiling  src/CombineHarvester/CombineTools/bin/YieldTable.cpp
>> Compiling  src/CombineHarvester/CombineTools/bin/hzz4l.cpp
>> Building LCG reflex dict from header file src/CombineHarvester/CombineTools/src/classes.h
>> Building shared library tmp/el9_amd64_gcc12/src/HiggsAnalysis/CombinedLimit/src/HiggsAnalysisCombinedLimit/libHiggsAnalysisCombinedLimit.so
src/CombineHarvester/CombineTools/bin/SMLegacyExample.cpp: In function 'int main()':
src/CombineHarvester/CombineTools/bin/SMLegacyExample.cpp:142:22: warning: loop variable 'e' of type 'const std::string&' {aka 'const std::__cxx11::basic_string<char>&'} binds to a temporary constructed from type 'const char* const' [-Wrange-loop-construct]
  142 |   for (string const& e : {"7TeV", "8TeV"}) {
      |                      ^
src/CombineHarvester/CombineTools/bin/SMLegacyExample.cpp:142:22: note: use non-reference type 'const std::string' {aka 'const std::__cxx11::basic_string<char>'} to make the copy explicit or 'const char* const&' to prevent copying
src/CombineHarvester/CombineTools/bin/SMLegacyExample.cpp:155:22: warning: loop variable 'e' of type 'const std::string&' {aka 'const std::__cxx11::basic_string<char>&'} binds to a temporary constructed from type 'const char* const' [-Wrange-loop-construct]
  155 |   for (string const& e : {"7TeV", "8TeV"}) {
      |                      ^
src/CombineHarvester/CombineTools/bin/SMLegacyExample.cpp:155:22: note: use non-reference type 'const std::string' {aka 'const std::__cxx11::basic_string<char>'} to make the copy explicit or 'const char* const&' to prevent copying
src/CombineHarvester/CombineTools/bin/SMLegacyExample.cpp:156:24: warning: loop variable 'p' of type 'const std::string&' {aka 'const std::__cxx11::basic_string<char>&'} binds to a temporary constructed from type 'const char* const' [-Wrange-loop-construct]
  156 |     for (string const& p : {"ggH", "qqH"}) {
      |                        ^
src/CombineHarvester/CombineTools/bin/SMLegacyExample.cpp:156:24: note: use non-reference type 'const std::string' {aka 'const std::__cxx11::basic_string<char>'} to make the copy explicit or 'const char* const&' to prevent copying
>> Compiling LCG dictionary: tmp/el9_amd64_gcc12/src/CombineHarvester/CombineTools/src/CombineHarvesterCombineTools/a/CombineHarvesterCombineTools_xr.cc

...
```