### PR TITLE
Fix compilation warning for deprecated boost::bind

### DIFF
--- a/CombinePdfs/bin/ParametricMSSM.cpp
+++ b/CombinePdfs/bin/ParametricMSSM.cpp
@@ -2,7 +2,8 @@
 // #include "boost/filesystem.hpp"
 // #include "boost/regex.hpp"
 // #include "boost/format.hpp"
-#include "boost/bind.hpp"
+// #include "boost/bind.hpp"
+#include "boost/lexical_cast.hpp"
 // #include "boost/assign/list_of.hpp"
 #include "CombineHarvester/CombineTools/interface/CombineHarvester.h"
 #include "CombineHarvester/CombineTools/interface/Observation.h"
@@ -20,7 +21,7 @@
 #include "RooHistPdf.h"
 #include "RooGenericPdf.h"
 
-using boost::bind;
+//using boost::bind;
 using std::string;
 using std::vector;
 using std::pair;

--- a/CombineTools/bin/MSSMYieldTable.cpp
+++ b/CombineTools/bin/MSSMYieldTable.cpp
@@ -4,13 +4,15 @@
 #include "boost/lexical_cast.hpp"
 #include "boost/algorithm/string.hpp"
 #include "boost/format.hpp"
-#include "boost/bind.hpp"
+//#include "boost/bind.hpp"
+#include "boost/bind/bind.hpp" // replaces "boost/bind.hpp"
 #include "boost/program_options.hpp"
 #include "CombineHarvester/CombineTools/interface/CombineHarvester.h"
 #include "CombineHarvester/CombineTools/interface/Utilities.h"
 #include "CombineHarvester/CombineTools/interface/TFileIO.h"
 
 namespace po = boost::program_options;
+using namespace boost::placeholders;
 
 using namespace std;
 

--- a/CombineTools/bin/MSSMtauptYieldTable.cpp
+++ b/CombineTools/bin/MSSMtauptYieldTable.cpp
@@ -4,13 +4,15 @@
 #include "boost/lexical_cast.hpp"
 #include "boost/algorithm/string.hpp"
 #include "boost/format.hpp"
-#include "boost/bind.hpp"
+//#include "boost/bind.hpp"
+#include "boost/bind/bind.hpp" // replaces "boost/bind.hpp"
 #include "boost/program_options.hpp"
 #include "CombineHarvester/CombineTools/interface/CombineHarvester.h"
 #include "CombineHarvester/CombineTools/interface/Utilities.h"
 #include "CombineHarvester/CombineTools/interface/TFileIO.h"
 
 namespace po = boost::program_options;
+using namespace boost::placeholders;
 
 using namespace std;
 


### PR DESCRIPTION
Some simple fixes to remove these compilation warnings:
```cpp
$ scramv1 b clean; scramv1 b -j$(nproc --ignore=2)

...

In file included from /cvmfs/cms.cern.ch/el9_amd64_gcc12/external/boost/1.80.0-87b5de10acd2f2c8a325345ad058b814/include/boost/bind.hpp:30,
                 from src/CombineHarvester/CombinePdfs/bin/ParametricMSSM.cpp:5:
/cvmfs/cms.cern.ch/el9_amd64_gcc12/external/boost/1.80.0-87b5de10acd2f2c8a325345ad058b814/include/boost/bind.hpp:36:1: note: '#pragma message: The practice of declaring the Bind placeholders (_1, _2, ...) in the global namespace is deprecated. Please use <boost/bind/bind.hpp> + using namespace boost::placeholders, or define BOOST_BIND_GLOBAL_PLACEHOLDERS to retain the current behavior.'
   36 | BOOST_PRAGMA_MESSAGE(
      | ^~~~~~~~~~~~~~~~~~~~

...

>> Compiling  src/CombineHarvester/CombineTools/bin/MSSMYieldTable.cpp
>> Compiling  src/CombineHarvester/CombineTools/bin/MSSMtauptYieldTable.cpp
>> Compiling  src/CombineHarvester/CombineTools/bin/NuisanceSummary.cpp
>> Compiling  src/CombineHarvester/CombineTools/bin/Plot1DScan.cpp
>> Compiling  src/CombineHarvester/CombineTools/bin/PlotMassScan.cpp
>> Compiling  src/CombineHarvester/CombineTools/bin/PlotTest.cpp
>> Compiling  src/CombineHarvester/CombineTools/bin/PostFit2DShapesFromWorkspace.cpp
>> Compiling  src/CombineHarvester/CombineTools/bin/PostFitPlot2.cpp
>> Compiling  src/CombineHarvester/CombineTools/bin/PostFitShapesFromWorkspace.cpp
>> Compiling  src/CombineHarvester/CombineTools/bin/PrePost.cpp
>> Compiling  src/CombineHarvester/CombineTools/bin/PrintPulls.cpp
>> Compiling  src/CombineHarvester/CombineTools/bin/RoundTrip.cpp
In file included from /cvmfs/cms.cern.ch/el9_amd64_gcc12/external/boost/1.80.0-87b5de10acd2f2c8a325345ad058b814/include/boost/smart_ptr/detail/sp_thread_sleep.hpp:22,
                 from /cvmfs/cms.cern.ch/el9_amd64_gcc12/external/boost/1.80.0-87b5de10acd2f2c8a325345ad058b814/include/boost/smart_ptr/detail/yield_k.hpp:23,
                 from /cvmfs/cms.cern.ch/el9_amd64_gcc12/external/boost/1.80.0-87b5de10acd2f2c8a325345ad058b814/include/boost/smart_ptr/detail/spinlock_gcc_atomic.hpp:14,
                 from /cvmfs/cms.cern.ch/el9_amd64_gcc12/external/boost/1.80.0-87b5de10acd2f2c8a325345ad058b814/include/boost/smart_ptr/detail/spinlock.hpp:42,
                 from /cvmfs/cms.cern.ch/el9_amd64_gcc12/external/boost/1.80.0-87b5de10acd2f2c8a325345ad058b814/include/boost/smart_ptr/detail/spinlock_pool.hpp:25,
                 from /cvmfs/cms.cern.ch/el9_amd64_gcc12/external/boost/1.80.0-87b5de10acd2f2c8a325345ad058b814/include/boost/smart_ptr/shared_ptr.hpp:29,
                 from /cvmfs/cms.cern.ch/el9_amd64_gcc12/external/boost/1.80.0-87b5de10acd2f2c8a325345ad058b814/include/boost/shared_ptr.hpp:17,
                 from /cvmfs/cms.cern.ch/el9_amd64_gcc12/external/boost/1.80.0-87b5de10acd2f2c8a325345ad058b814/include/boost/format/alt_sstream.hpp:22,
                 from /cvmfs/cms.cern.ch/el9_amd64_gcc12/external/boost/1.80.0-87b5de10acd2f2c8a325345ad058b814/include/boost/format/internals.hpp:24,
                 from /cvmfs/cms.cern.ch/el9_amd64_gcc12/external/boost/1.80.0-87b5de10acd2f2c8a325345ad058b814/include/boost/format.hpp:38,
                 from src/CombineHarvester/CombineTools/bin/MSSMYieldTable.cpp:6:
/cvmfs/cms.cern.ch/el9_amd64_gcc12/external/boost/1.80.0-87b5de10acd2f2c8a325345ad058b814/include/boost/bind.hpp:36:1: note: '#pragma message: The practice of declaring the Bind placeholders (_1, _2, ...) in the global namespace is deprecated. Please use <boost/bind/bind.hpp> + using namespace boost::placeholders, or define BOOST_BIND_GLOBAL_PLACEHOLDERS to retain the current behavior.'
   36 | BOOST_PRAGMA_MESSAGE(
      | ^~~~~~~~~~~~~~~~~~~~
>> Compiling  src/CombineHarvester/CombineTools/bin/SBWeighted.cpp
In file included from /cvmfs/cms.cern.ch/el9_amd64_gcc12/external/boost/1.80.0-87b5de10acd2f2c8a325345ad058b814/include/boost/smart_ptr/detail/sp_thread_sleep.hpp:22,
                 from /cvmfs/cms.cern.ch/el9_amd64_gcc12/external/boost/1.80.0-87b5de10acd2f2c8a325345ad058b814/include/boost/smart_ptr/detail/yield_k.hpp:23,
                 from /cvmfs/cms.cern.ch/el9_amd64_gcc12/external/boost/1.80.0-87b5de10acd2f2c8a325345ad058b814/include/boost/smart_ptr/detail/spinlock_gcc_atomic.hpp:14,
                 from /cvmfs/cms.cern.ch/el9_amd64_gcc12/external/boost/1.80.0-87b5de10acd2f2c8a325345ad058b814/include/boost/smart_ptr/detail/spinlock.hpp:42,
                 from /cvmfs/cms.cern.ch/el9_amd64_gcc12/external/boost/1.80.0-87b5de10acd2f2c8a325345ad058b814/include/boost/smart_ptr/detail/spinlock_pool.hpp:25,
                 from /cvmfs/cms.cern.ch/el9_amd64_gcc12/external/boost/1.80.0-87b5de10acd2f2c8a325345ad058b814/include/boost/smart_ptr/shared_ptr.hpp:29,
                 from /cvmfs/cms.cern.ch/el9_amd64_gcc12/external/boost/1.80.0-87b5de10acd2f2c8a325345ad058b814/include/boost/shared_ptr.hpp:17,
                 from /cvmfs/cms.cern.ch/el9_amd64_gcc12/external/boost/1.80.0-87b5de10acd2f2c8a325345ad058b814/include/boost/format/alt_sstream.hpp:22,
                 from /cvmfs/cms.cern.ch/el9_amd64_gcc12/external/boost/1.80.0-87b5de10acd2f2c8a325345ad058b814/include/boost/format/internals.hpp:24,
                 from /cvmfs/cms.cern.ch/el9_amd64_gcc12/external/boost/1.80.0-87b5de10acd2f2c8a325345ad058b814/include/boost/format.hpp:38,
                 from src/CombineHarvester/CombineTools/bin/MSSMtauptYieldTable.cpp:6:
/cvmfs/cms.cern.ch/el9_amd64_gcc12/external/boost/1.80.0-87b5de10acd2f2c8a325345ad058b814/include/boost/bind.hpp:36:1: note: '#pragma message: The practice of declaring the Bind placeholders (_1, _2, ...) in the global namespace is deprecated. Please use <boost/bind/bind.hpp> + using namespace boost::placeholders, or define BOOST_BIND_GLOBAL_PLACEHOLDERS to retain the current behavior.'
   36 | BOOST_PRAGMA_MESSAGE(
      | ^~~~~~~~~~~~~~~~~~~~
>> Compiling  src/CombineHarvester/CombineTools/bin/SMLegacyExample.cpp

...
```

I separated this from PR https://github.com/cms-analysis/CombineHarvester/pull/341 because this might depend on the boost version, so I'll let the CombineHarvester maintainers decide if this is necessary. Starting from Boost 1.73.0, putting the `boost::bind` placeholders (`_1`, `_2`, …) in the global namespace has been deprecated. You can see the version of boost per SCRAM architecture in CVMFS here:
```bash
lt /cvmfs/cms.cern.ch/*/external/boost/1.[567]*/include/boost/bind.hpp
```
Older version of SLC7 might still use boost 1.72.0, while newer SLC7 versions like `slc7_amd64_gcc10` point to 1.75.0 or newer. Most of the EL8 and EL9 use 1.78.0 or newer. For example, `el9_amd64_gcc12`, which I used to setup `CMSSW_14_1_0_pre4` has 1.80.0.