### PR TITLE
Add CheckBinErrors to validate datacards with autoMCStats

### DIFF
--- a/CombineTools/interface/ValidationTools.h
+++ b/CombineTools/interface/ValidationTools.h
@@ -30,6 +30,9 @@ void CheckEmptyShapes(CombineHarvester& cb, json &jsobj);
 void CheckEmptyShapes(CombineHarvester& cb);
 void CheckEmptyBins(CombineHarvester& cb, json &jsobj);
 void CheckEmptyBins(CombineHarvester& cb);
+bool HistErrorsAreSqrtN(const TH1* hist, double rate);
+void CheckBinErrors(CombineHarvester& cb, double maxRelBinErr, json& jsobj);
+void CheckBinErrors(CombineHarvester& cb, double maxRelBinErr);
 void CheckNormEff(CombineHarvester& cb, double maxNormEff, json &jsobj);
 void CheckNormEff(CombineHarvester& cb, double maxNormEff);
 void CheckSizeOfShapeEffect(CombineHarvester& cb, json& jsobj);
@@ -38,7 +41,7 @@ void CheckSmallSignals(CombineHarvester& cb, double minSigFrac, json& jsobj);
 void CheckSmallSignals(CombineHarvester& cb, double minSigFrac);
 void ValidateShapeTemplates(CombineHarvester& cb, json &jsobj);
 void ValidateShapeTemplates(CombineHarvester& cb);
-void ValidateCards(CombineHarvester& cb, std::string const& filename, double maxNormEff, double minSigFrac);
+void ValidateCards(CombineHarvester& cb, std::string const& filename, double maxNormEff, double minSigFrac, double maxRelBinErr);
 
 }
 

--- a/CombineTools/interface/ValidationToolsNoJSON.h
+++ b/CombineTools/interface/ValidationToolsNoJSON.h
@@ -18,11 +18,12 @@ void PrintSystematic(ch::Systematic *syst);
 void ValidateShapeUncertaintyDirection(CombineHarvester& cb);
 void CheckEmptyShapes(CombineHarvester& cb);
 void CheckEmptyBins(CombineHarvester& cb);
+void CheckBinErrors(CombineHarvester& cb, double maxRelBinErr);
 void CheckNormEff(CombineHarvester& cb, double maxNormEff);
 void CheckSizeOfShapeEffect(CombineHarvester& cb);
 void CheckSmallSignals(CombineHarvester& cb, double minSigFrac);
 void ValidateShapeTemplates(CombineHarvester& cb);
-void ValidateCards(CombineHarvester& cb, std::string const& filename, double maxNormEff, double minSigFrac);
+void ValidateCards(CombineHarvester& cb, std::string const& filename, double maxNormEff, double minSigFrac, double maxRelBinErr);
 
 }
 

--- a/CombineTools/python/ch.py
+++ b/CombineTools/python/ch.py
@@ -23,6 +23,7 @@ CheckEmptyShapes = cppyy.gbl.ch.CheckEmptyShapes
 CheckNormEff = cppyy.gbl.ch.CheckNormEff
 CheckSizeOfShapeEffect = cppyy.gbl.ch.CheckSizeOfShapeEffect
 CheckSmallSignals = cppyy.gbl.ch.CheckSmallSignals
+CheckBinErrors = cppyy.gbl.ch.CheckBinErrors
 CloneObs = cppyy.gbl.ch.CloneObs
 CloneProcs = cppyy.gbl.ch.CloneProcs
 CloneProcsAndSysts = cppyy.gbl.ch.CloneProcsAndSysts

--- a/CombineTools/scripts/ValidateDatacards.py
+++ b/CombineTools/scripts/ValidateDatacards.py
@@ -22,17 +22,19 @@ parser = argparse.ArgumentParser()
 parser.add_argument('cards',
                     help='Specifies the full path to the datacards to check')
 parser.add_argument('--printLevel', '-p', default=1, type=int,
-                    help='Specify the level of info printing (0-3, default:1)')
+                    help='Specify the level of info printing (0-3, default:%(default)s)')
 parser.add_argument('--readOnly', action='store_true',
                     help='If this is enabled, skip validation and only read the output json')
 parser.add_argument('--checkUncertOver', '-c', default=0.1, type=float,
-                    help='Report uncertainties which have a normalisation effect larger than this fraction (default:0.1)')
+                    help='Report uncertainties which have a normalisation effect larger than this fraction (default:%(default)s)')
 parser.add_argument('--reportSigUnder', '-s', default=0.001, type=float,
-                    help='Report signals contributing less than this fraction of the total in a channel (default:0.001)')
+                    help='Report signals contributing less than this fraction of the total in a channel (default:%(default)s)')
+parser.add_argument('--reportBinErrOver', '-b', default=2, type=float,
+                    help='Report total bin error over this fraction of the total bin content (default:%(default)s)')
 parser.add_argument('--jsonFile', default='validation.json',
-                    help='Path to the json file to read/write results from (default:validation.json)')
+                    help='Path to the json file to read/write results from (default:%(default)s)')
 parser.add_argument('--mass', default='*',
-                    help='Signal mass to use (default:*)')
+                    help='Signal mass to use (default:%(default)s)')
 
 args = parser.parse_args()
 
@@ -41,7 +43,7 @@ def print_uncertainty(js_dict, dict_key, err_type_msg):
     num_problems_peruncert = {}
     if dict_key in js_dict:
         for uncert in js_dict[dict_key]:
-            probs=0;
+            probs=0
             for mybin in js_dict[dict_key][uncert]:
                 num_problems+=len(list(js_dict[dict_key][uncert][mybin].keys()))
                 probs+=len(list(js_dict[dict_key][uncert][mybin].keys()))
@@ -62,7 +64,6 @@ def print_process(js_dict, dict_key, err_type_msg):
     num_problems_peruncert = {}
     if dict_key in js_dict:
         for mybin in js_dict[dict_key]:
-            probs=0;
             num_problems+=len(js_dict[dict_key][mybin])
             num_problems_peruncert[mybin]=len(js_dict[dict_key][mybin])
         print(">>>There were ",num_problems, "warnings of type ",err_type_msg)
@@ -70,14 +71,13 @@ def print_process(js_dict, dict_key, err_type_msg):
             for mybin in js_dict[dict_key]:
                 print("    For bin",mybin, "there were ", num_problems_peruncert[mybin]," such warnings. The affected processes are: ", json.dumps(js_dict[dict_key][mybin]))
     else:
-        print(">>>There were no warnings of type", err_type_msg)
+        print(">>>There were no warnings of type ", err_type_msg)
 
 def print_process_info(js_dict, dict_key, err_type_msg):
     num_problems=0
     num_problems_peruncert = {}
     if dict_key in js_dict:
         for mybin in js_dict[dict_key]:
-            probs=0;
             num_problems+=len(js_dict[dict_key][mybin])
             num_problems_peruncert[mybin]=len(js_dict[dict_key][mybin])
         print(">>>INFO: there were ",num_problems," alerts of type ",err_type_msg)
@@ -85,14 +85,13 @@ def print_process_info(js_dict, dict_key, err_type_msg):
             for mybin in js_dict[dict_key]:
                 print("    For bin",mybin, "there were ", num_problems_peruncert[mybin]," such alerts. The affected processes are: ", json.dumps(js_dict[dict_key][mybin]))
     else:
-        print(">>>There were no alerts of type", err_type_msg)
+        print(">>>There were no alerts of type ", err_type_msg)
 
 def print_bin(js_dict, dict_key, err_type_msg):
     num_problems=0
     num_problems_peruncert = {}
     if dict_key in js_dict:
         for mybin in js_dict[dict_key]:
-            probs=0;
             num_problems+=len(js_dict[dict_key][mybin])
             num_problems_peruncert[mybin]=len(js_dict[dict_key][mybin])
         print(">>>There were ",num_problems, "warnings of type ",err_type_msg)
@@ -100,7 +99,7 @@ def print_bin(js_dict, dict_key, err_type_msg):
             for mybin in js_dict[dict_key]:
                 print("    For bin",mybin, "there were ", num_problems_peruncert[mybin]," such warnings. The affected bins of the template are: ", json.dumps(js_dict[dict_key][mybin]))
     else:
-        print(">>>There were no warnings of type", err_type_msg)
+        print(">>>There were no warnings of type ", err_type_msg)
 
 
 
@@ -110,8 +109,7 @@ cb.SetFlag('workspaces-use-clone', True)
 
 if not args.readOnly:
     cb.ParseDatacard(args.cards,"","",mass=args.mass)
-
-    ch.ValidateCards(cb,args.jsonFile,args.checkUncertOver,args.reportSigUnder)
+    ch.ValidateCards(cb,args.jsonFile,args.checkUncertOver,args.reportSigUnder,args.reportBinErrOver)
 
 if args.printLevel > 0:
     print("================================")
@@ -125,10 +123,12 @@ if args.printLevel > 0:
             print_uncertainty(data,"uncertVarySameDirect","\'up/down templates vary the yield in the same direction\'")
             print_uncertainty(data,"uncertTemplSame","\'up/down templates are identical\'")
             print_uncertainty(data,"emptySystematicShape","\'At least one of the up/down systematic uncertainty templates is empty\'")
-            print_uncertainty(data,"largeNormEff","\'Uncertainty has normalisation effect of more than %.1f%%\'"% (args.checkUncertOver*100))
+            print_uncertainty(data,"largeNormEff","\'Uncertainty has normalisation effect of more than %.1f%%\'"%(args.checkUncertOver*100))
             print_uncertainty(data,"smallShapeEff","\'Uncertainty probably has no genuine shape effect\'")
             print_process(data,"emptyProcessShape","\'Empty process\'")
             print_bin(data,"emptyBkgBin","\'Bins of the template empty in background\'")
+            print_process(data,"binErrorIsNotSumw2","\'Histogram bin errors are not sqrt(sumw2), needed for accurate bin-by-bin uncertainties\'")
+            print_bin(data,"largeBinError","\'Bins of the background template have a relative bin error larger than %.1f%%\'"%(args.reportBinErrOver*100))
             print_process_info(data,"smallSignalProc","\'Small signal process\'")
             print_process_info(data,"smallShapeEff1bin","\'Shape uncertainties with 1 bin only. You can consider replacing them with lnN\'")
 

--- a/CombineTools/src/ValidationTools.cc
+++ b/CombineTools/src/ValidationTools.cc
@@ -24,8 +24,6 @@ void PrintProc(ch::Process *proc){
   std::cout<<"Process "<<proc->process()<<" in region "<<proc->bin()<<" :";
 }
 
-
-
 void ValidateShapeUncertaintyDirection(CombineHarvester& cb, json& jsobj){
   cb.ForEachSyst([&](ch::Systematic *sys){
     if(sys->type()=="shape" && ( (sys->value_u() > 1. && sys->value_d() > 1.) || (sys->value_u() < 1. && sys->value_d() < 1.))){
@@ -78,25 +76,19 @@ void ValidateShapeTemplates(CombineHarvester& cb){
       }
       if(is_same){
         PrintSystematic(sys);
-        std::cout<<"Up/Down templates are identical: up variation: "<<sys->value_u()<<", down variation: "<<sys->value_d()<<std::endl;
+        std::cout<<" Up/Down templates are identical: up variation: "<<sys->value_u()<<", down variation: "<<sys->value_d()<<std::endl;
       }
     }
   });
 }
-
-
 
 void CheckEmptyShapes(CombineHarvester& cb, json& jsobj){
   std::vector<ch::Process*> empty_procs;
   auto bins = cb.bin_set();
   cb.ForEachProc([&](ch::Process *proc){
     if(proc->rate()==0.){
-      empty_procs.push_back(proc); 
-      if (jsobj["emptyProcessShape"][proc->bin()] !=NULL){
-        jsobj["emptyProcessShape"][proc->bin()].push_back(proc->process());
-      } else {
-        jsobj["emptyProcessShape"][proc->bin()] = {proc->process()};
-      }
+      empty_procs.push_back(proc);
+      jsobj["emptyProcessShape"][proc->bin()].push_back(proc->process());
    }
   });
   cb.ForEachSyst([&](ch::Systematic *sys){
@@ -116,7 +108,7 @@ void CheckEmptyShapes(CombineHarvester& cb){
   std::vector<ch::Process*> empty_procs;
   cb.ForEachProc([&](ch::Process *proc){
     if(proc->rate()==0.){
-      empty_procs.push_back(proc); 
+      empty_procs.push_back(proc);
       PrintProc(proc);
       std::cout<<" has 0 yield"<<std::endl;
    }
@@ -139,7 +131,7 @@ void CheckNormEff(CombineHarvester& cb, double maxNormEff){
   std::vector<ch::Process*> empty_procs;
   cb.ForEachProc([&](ch::Process *proc){
     if(proc->rate()==0.){
-      empty_procs.push_back(proc); 
+      empty_procs.push_back(proc);
    }
   });
   cb.ForEachSyst([&](ch::Systematic *sys){
@@ -149,7 +141,7 @@ void CheckNormEff(CombineHarvester& cb, double maxNormEff){
     }
     if(!no_check && ((sys->type()=="shape" &&  (sys->value_u()-1 > maxNormEff || sys->value_u()-1 < -maxNormEff  || sys->value_d()-1>maxNormEff || sys->value_d()-1< -maxNormEff)) || (sys->type()=="lnN" && (sys->value_u()-1 > maxNormEff || sys->value_u()-1 < - maxNormEff) ))){
       PrintSystematic(sys);
-      std::cout<<"Uncertainty has a large normalisation effect: up variation: "<<sys->value_u()<<" Down variation: "<<sys->value_d()<<std::endl;
+      std::cout<<" Uncertainty has a large normalisation effect: up variation: "<<sys->value_u()<<" Down variation: "<<sys->value_d()<<std::endl;
     }
   });
 }
@@ -158,7 +150,7 @@ void CheckNormEff(CombineHarvester& cb, double maxNormEff, json& jsobj){
   std::vector<ch::Process*> empty_procs;
   cb.ForEachProc([&](ch::Process *proc){
     if(proc->rate()==0.){
-      empty_procs.push_back(proc); 
+      empty_procs.push_back(proc);
    }
   });
   cb.ForEachSyst([&](ch::Systematic *sys){
@@ -173,13 +165,12 @@ void CheckNormEff(CombineHarvester& cb, double maxNormEff, json& jsobj){
 }
 
 void CheckEmptyBins(CombineHarvester& cb){
-  TH1F tothist;
   auto bins = cb.bin_set();
   for(auto b : bins){
     auto cb_bin_backgrounds = cb.cp().bin({b}).backgrounds();
-    tothist = cb_bin_backgrounds.GetShape();
+    const TH1F& tothist = cb_bin_backgrounds.GetShape();
     for(int i=1;i<=tothist.GetNbinsX();i++){
-      if(tothist.GetBinContent(i)<=0){ 
+      if(tothist.GetBinContent(i)<=0){
         std::cout<<"Channel "<<b<<" bin "<<i<<" of the templates is empty in background"<<std::endl;
       }
     }
@@ -187,23 +178,120 @@ void CheckEmptyBins(CombineHarvester& cb){
 }
 
 void CheckEmptyBins(CombineHarvester& cb, json& jsobj){
-  TH1F tothist;
   auto bins = cb.bin_set();
   for(auto b : bins){
     auto cb_bin_backgrounds = cb.cp().bin({b}).backgrounds();
-    tothist = cb_bin_backgrounds.GetShape();
+    const TH1F& tothist = cb_bin_backgrounds.GetShape();
     for(int i=1;i<=tothist.GetNbinsX();i++){
-      if(tothist.GetBinContent(i)<=0){ 
-        if (jsobj["emptyBkgBin"][b] !=NULL){
-          jsobj["emptyBkgBin"][b].push_back(i);
-        } else {
-          jsobj["emptyBkgBin"][b] = {i};
+      if(tothist.GetBinContent(i)<=0){
+        jsobj["emptyBkgBin"][b].push_back(i);
+      }
+    }
+  }
+}
+
+bool HistErrorsAreSqrtN(const TH1* hist_norm, double rate=1.0) {
+  TH1* hist = (TH1*) hist_norm->Clone();
+  hist->Scale(rate);
+  for(int i=1; i<hist->GetNcells(); ++i) { // exclude under-/overflow
+    double binContent = std::abs(hist->GetBinContent(i));
+    if(binContent!=0 && !hist->IsBinUnderflow(i) && !hist->IsBinOverflow(i)){
+      double binError   = hist->GetBinError(i);
+      double errSquared = binError*binError;
+      double threshold  = 1e-6 * std::max(binContent,errSquared);
+      if(std::abs(binContent-errSquared)>threshold){
+        return false; // at least one bin error is not sqrt(N)
+      }
+    }
+  }
+  return true; // all bin errors are sqrt(N) within 1e-6 tolerance
+}
+
+/**
+ * Check if bin errors are set correctly.
+ * 
+ * To compute the bin-by-bin uncertainties correctly with autoMCStats,
+ * the bin errors are expected to be the square root of the sum of weights, sqrt(sumw2).
+ * This method checks the bin errors are not a Poisson error or sqrt(N),
+ * and if the relative uncertainty is not too large (indicating too large weights, or a bug).
+ */
+void CheckBinErrors(CombineHarvester& cb, double maxRelBinErr){
+  const std::vector<std::string> bins_bbb = Set2Vec(cb.GetAutoMCStatsBins());
+  auto cb_bin = cb.cp().bin(bins_bbb);
+  cb_bin.ForEachProc([&](ch::Process *proc){
+    const TH1* shape = proc->shape();
+    if(!shape){
+      return;
+    }
+    const int errOpt = shape->GetBinErrorOption();
+    if(errOpt!=TH1F::kNormal){
+      std::string errEnum = (errOpt==TH1F::kPoisson ? "TH1::kPoisson" : errOpt==TH1F::kPoisson2 ? "TH1::kPoisson2" : std::to_string(errOpt));
+      PrintProc(proc);
+      std::cout<<" Bin error option is "<<errEnum<<"="<<errOpt<<"!=TH1::kNormal, but sqrt(sumw2) is needed for autoMCStats"<<std::endl;
+      return;
+    }
+    if(shape->GetNcells()>=3 && shape->GetSumw2N()==0){
+      PrintProc(proc);
+      std::cout<<" Sumw2 is not defined, which is needed for autoMCStats"<<std::endl;
+      return;
+    }
+    if(HistErrorsAreSqrtN(shape,proc->rate())){
+      PrintProc(proc);
+      std::cout<<" Bin errors are sqrt(N) instead of sqrt(sumw2), needed for autoMCStats"<<std::endl;
+      return;
+    }
+  });
+  if(maxRelBinErr<=0){
+    return;
+  }
+  for(auto b : cb_bin.bin_set()){
+    const TH1F& tothist = cb.cp().bin({b}).backgrounds().GetShape();
+    for(int i=1;i<=tothist.GetNbinsX();i++){
+      if(tothist.GetBinContent(i)!=0){
+        double relErr = tothist.GetBinError(i) / tothist.GetBinContent(i);
+        if(relErr>maxRelBinErr){
+          std::cout<<"Channel "<<b<<" bin "<<i<<" of the templates is has large relative bin error: "<<relErr<<" > "<<maxRelBinErr<<std::endl;
         }
       }
     }
   }
 }
 
+void CheckBinErrors(CombineHarvester& cb, double maxRelBinErr, json& jsobj){
+  std::vector<std::string> bins = Set2Vec(cb.GetAutoMCStatsBins());
+  auto cb_bin = cb.cp().bin(bins);
+  cb_bin.ForEachProc([&](ch::Process *proc){
+    const TH1* shape = proc->shape();
+    if(!shape){
+      return;
+    }
+    const int errOpt = shape->GetBinErrorOption();
+    if(errOpt!=TH1F::kNormal){
+      std::string errEnum = (errOpt==TH1F::kPoisson ? "TH1::kPoisson" : errOpt==TH1F::kPoisson2 ? "TH1::kPoisson2" : std::to_string(errOpt));
+      jsobj["binErrorIsNotSumw2"][proc->bin()][proc->process()] = "BinErrorOption="+errEnum;
+      return;
+    }
+    if(shape->GetNcells()>=3 && shape->GetSumw2N()==0){
+      jsobj["binErrorIsNotSumw2"][proc->bin()][proc->process()] = "NoSumw2Defined";
+      return;
+    }
+    if(HistErrorsAreSqrtN(shape,proc->rate())){
+      jsobj["binErrorIsNotSumw2"][proc->bin()][proc->process()] = "BinErrorIsSqrtN";
+      return;
+    }
+  });
+  for(auto b : cb_bin.bin_set()){
+    const TH1F& tothist = cb.cp().bin({b}).backgrounds().GetShape();
+    for(int i=1;i<=tothist.GetNbinsX();i++){
+      if(tothist.GetBinContent(i)!=0){
+        double relErr = tothist.GetBinError(i) / tothist.GetBinContent(i);
+        if(relErr>maxRelBinErr){
+          jsobj["largeBinError"][b].push_back(i);
+        }
+      }
+    }
+  }
+}
 
 void CheckSizeOfShapeEffect(CombineHarvester& cb){
   double diff_lim=0.001;
@@ -228,12 +316,11 @@ void CheckSizeOfShapeEffect(CombineHarvester& cb){
       }
       if(up_diff<diff_lim && down_diff<diff_lim){
         PrintSystematic(sys);
-        std::cout<<"Uncertainty probably has no genuine shape effect. Summed relative difference per bin between normalised nominal and up shape: "<<up_diff<<" between normalised nominal and down shape: "<<down_diff<<" . If you are using 1-bin shapes you can ignore this warning, but you can consider using lnN instead of a shape uncertainty"<<std::endl;
+        std::cout<<" Uncertainty probably has no genuine shape effect. Summed relative difference per bin between normalised nominal and up shape: "<<up_diff<<" between normalised nominal and down shape: "<<down_diff<<" . If you are using 1-bin shapes you can ignore this warning, but you can consider using lnN instead of a shape uncertainty"<<std::endl;
       }
     }
   });
 }
-
 
 void CheckSizeOfShapeEffect(CombineHarvester& cb, json& jsobj){
   double diff_lim=0.001;
@@ -258,16 +345,15 @@ void CheckSizeOfShapeEffect(CombineHarvester& cb, json& jsobj){
       }
       if (hist_u->GetNbinsX() == 1) jsobj["smallShapeEff1bin"][sys->name()][sys->bin()][sys->process()]={{"diff_u",up_diff},{"diff_d",down_diff}};
       else {if(up_diff<diff_lim && down_diff<diff_lim) jsobj["smallShapeEff"][sys->name()][sys->bin()][sys->process()]={{"diff_u",up_diff},{"diff_d",down_diff}}; }
-    } 
+    }
   });
 }
 
-void CheckSmallSignals(CombineHarvester& cb,double minSigFrac){
+void CheckSmallSignals(CombineHarvester& cb, double minSigFrac){
   auto bins = cb.bin_set();
   for(auto b : bins){
     auto cb_bin_signals = cb.cp().bin({b}).signals();
-    auto cb_bin_backgrounds = cb.cp().bin({b}).backgrounds();
-    auto cb_bin = cb.cp().bin({b}); 
+    auto cb_bin = cb.cp().bin({b});
     double sigrate = cb_bin_signals.GetRate();
     for(auto p : cb_bin_signals.process_set()){
       if(cb_bin_signals.cp().process({p}).GetRate() < minSigFrac*sigrate){
@@ -277,13 +363,11 @@ void CheckSmallSignals(CombineHarvester& cb,double minSigFrac){
   }
 }
 
-
 void CheckSmallSignals(CombineHarvester& cb, double minSigFrac, json& jsobj){
   auto bins = cb.bin_set();
   for(auto b : bins){
     auto cb_bin_signals = cb.cp().bin({b}).signals();
-    auto cb_bin_backgrounds = cb.cp().bin({b}).backgrounds();
-    auto cb_bin = cb.cp().bin({b}); 
+    auto cb_bin = cb.cp().bin({b});
     double sigrate = cb_bin_signals.GetRate();
     for(auto p : cb_bin_signals.process_set()){
       if(cb_bin_signals.cp().process({p}).GetRate() < minSigFrac*sigrate){
@@ -292,29 +376,29 @@ void CheckSmallSignals(CombineHarvester& cb, double minSigFrac, json& jsobj){
     }
   }
 }
-  
 
-void ValidateCards(CombineHarvester& cb, std::string const& filename, double maxNormEff, double minSigFrac){
- json output_js; 
- bool is_shape_card=1;
- cb.ForEachProc([&](ch::Process *proc){
-   if(proc->pdf()||!(proc->shape())){
-     is_shape_card=0;
+void ValidateCards(CombineHarvester& cb, std::string const& filename, double maxNormEff, double minSigFrac, double maxRelBinErr=2.){
+  json output_js;
+  bool is_shape_card=1;
+  cb.ForEachProc([&](ch::Process *proc){
+    if(proc->pdf()||!(proc->shape())){
+      is_shape_card=0;
     }
- });
- if(is_shape_card){     
-   ValidateShapeUncertaintyDirection(cb, output_js);      
-   CheckSizeOfShapeEffect(cb, output_js);
-   ValidateShapeTemplates(cb,output_js);
-   CheckEmptyBins(cb,output_js);
- } else {
-   std::cout<<"Not a shape-based datacard / shape-based datacard using RooDataHist. Skipping checks on systematic shapes."<<std::endl;
- }
- CheckEmptyShapes(cb, output_js);      
- CheckNormEff(cb, maxNormEff, output_js);
- CheckSmallSignals(cb,minSigFrac, output_js);
- std::ofstream outfile(filename);
- outfile <<std::setw(4)<<output_js<<std::endl;
+  });
+  if(is_shape_card){
+    ValidateShapeUncertaintyDirection(cb, output_js);
+    CheckSizeOfShapeEffect(cb, output_js);
+    ValidateShapeTemplates(cb, output_js);
+    CheckEmptyBins(cb, output_js);
+    CheckBinErrors(cb, maxRelBinErr, output_js); // for accurate autoMCStats
+  } else {
+    std::cout<<"Not a shape-based datacard / shape-based datacard using RooDataHist. Skipping checks on systematic shapes."<<std::endl;
+  }
+  CheckEmptyShapes(cb, output_js);
+  CheckNormEff(cb, maxNormEff, output_js);
+  CheckSmallSignals(cb,minSigFrac, output_js);
+  std::ofstream outfile(filename);
+  outfile <<std::setw(4)<<output_js<<std::endl;
 }
 
 }

--- a/CombineTools/src/classes_def.xml
+++ b/CombineTools/src/classes_def.xml
@@ -3,6 +3,7 @@
   <class name="ch::BinByBinFactory" transient="true" />
   <class name="ch::CardWriter" transient="true" />
   <function name="ch::CheckEmptyBins" />
+  <function name="ch::CheckBinErrors" />
   <function name="ch::CheckEmptyShapes" />
   <function name="ch::CheckNormEff" />
   <function name="ch::CheckSizeOfShapeEffect" />


### PR DESCRIPTION
This PR adds a pair of `CheckBinErrors` methods to the `ValidatoonTools` with some basic checks of the bin error to ensure they make sense for use by `autoMCStats`.

# Description
These are the checks done by `CheckBinErrors` in `ValidationTools.cpp`
1. For each bin & process: Check that the bin error option is set correctly, which should be `TH1::kNormal`. The other options like `TH1::kPoisson` would change the value of `TH1::GetBinError`.
1. For each bin & process: Check that histogram has a `Sumw2` array defined; otherwise [`TH1::GetBinError`](https://root.cern/doc/v630/TH1_8cxx_source.html#l08980) returns sqrt(N). I think this might be redundant because the CombineHarvester creates a new TH1 object for which the sumw2 is (re)created by default.
1. For each bin & process: Check that _all_ bin errors are not suspiciously close to sqrt(N) with a tolerance of 1e6. If at least one bin error is different to sqrt(N), no warning is raised.
1. For each bin: Check that the bin error of the total expected background is not larger than `x` times the bin content, where by default `x=2.`, and can be configured by the user, or via the `--reportBinErrOver` option to `ValidateDatacards.py`.

Each of these give their own specific warning, which is either printed or written to the validation JSON.

The python bindings are added, so it can be used by `ValidateDatacards.py`.

# Motivation
The reason for adding this is because I ran into a couple of cases in Combine review and on the CAT CMS Talk where analyzers reported large pre-fit uncertainties with the use of `autoMCStats`. It turned out that the input histograms had bin errors that were sqrt(N) instead of sqrt(sumw2). Both cases were probably because of a misuse of `SetBinError`, where they naively/manually set sqrt(N), or perhaps the wrong histogram settings (bin error option or missing sumw2).

The analyzers only reported this because they observed large bin errors. In both cases, the expected bin contents were N <<< 1 and therefore the relative bin error created by `autoMCStats` was sqrt(N)/N >>> 1. I fear this happens more often than we know, as most cases with N > 1 got undetected. As `ValidationDatacards.py` is now part of the datacard validation pipeline, these new checks might help to flag these issues with some specificity.

# Tests

Attached is a simple python script to generate several scenarios to test different combinations of the four checks above, as well as a simple C++ script to validate datacards.
- [generateDataCardForAutoMCStats.py](https://github.com/user-attachments/files/25724855/generateDataCardForAutoMCStats.py)
- [ValidateDatacards.cpp](https://github.com/user-attachments/files/25724853/ValidateDatacards.cpp)

```bash
# download files
cd $CMSSW_BASE/src
wget -O generateDataCardForAutoMCStats.py https://github.com/user-attachments/files/25724855/generateDataCardForAutoMCStats.py
wget -O CombineHarvester/CombineTools/bin/ValidateDatacard.cpp https://github.com/user-attachments/files/25724853/ValidateDatacards.cpp

# generate some toy datacards
./generateDataCardForAutoMCStats.py

# using ValidateDatacards.py 
for t in _nSw2_nPsn _nSw2_wPsn _wSw2_nPsn _wSw2_wPsn _largeBinErr _sqrtNBinErr; do echo; echo $t; CombineHarvester/CombineTools/scripts/ValidateDatacards.py datacard$t.txt --jsonFile validation$t.json --reportBinErrOver 3 -p 2; done

# using the attached C++ macro
for t in _nSw2_nPsn _nSw2_wPsn _wSw2_nPsn _wSw2_wPsn _largeBinErr _sqrtNBinErr; do echo; echo $t; ValidateDatacards datacard$t.txt; done
```
These give me validation JSON with the following warnings:
```json
// _nSw2_nPsn: no Sumw2 defined, BinErrorOption==kNormal
// Note that CombineHarvestor recreates sumw2 somehow, but bin errors are still sqrt(N)
    "binErrorIsNotSumw2": {
        "bin1": {
            "exp_nSw2_nPsn": "BinErrorIsSqrtN"
        }
    },

// _nSw2_wPsn: no Sumw2 defined, BinErrorOption==kPoisson
    "binErrorIsNotSumw2": {
        "bin1": {
            "exp_nSw2_wPsn": "BinErrorOption=TH1::kPoisson"
        }
    },

// _wSw2_nPsn: Sumw2 defined, BinErrorOption==kNormal
// no error

// _wSw2_wPsn: Sumw2 defined, BinErrorOption==kPoisson
    "binErrorIsNotSumw2": {
        "bin1": {
            "exp_wSw2_wPsn": "BinErrorOption=TH1::kPoisson"
        }
    },

// _largeBinErr: inflated bin errors (above 2x bin content)
    "largeBinError": {
        "bin1": [
            1,
            3,
            5,
            7
        ]
    },

// _sqrtNBinErr: manually set all bin errors to sqrt(N)
    "binErrorIsNotSumw2": {
        "bin1": {
            "exp_sqrtNBinErr": "BinErrorIsSqrtN"
        }
    },

```

This is the output the user sees from `ValidationDatacards.py`:
```bash
$ for t in _nSw2_nPsn _nSw2_wPsn _wSw2_nPsn _wSw2_wPsn _largeBinErr _sqrtNBinErr; do echo; echo $t; CombineHarvester/CombineTools/scripts/Validate
Datacards.py datacard$t.txt --jsonFile validation$t.json --reportBinErrOver 3 -p 2; done 

_nSw2_nPsn
[SetFlag] Changing value of flag "check-negative-bins-on-import" from 1 to 0
[SetFlag] Changing value of flag "workspaces-use-clone" from 0 to 1
================================
=======Validation results=======
================================
>>>There were no warnings of type  'up/down templates vary the yield in the same direction'
>>>There were no warnings of type  'up/down templates are identical'
>>>There were no warnings of type  'At least one of the up/down systematic uncertainty templates is empty'
>>>There were  1 warnings of type  'Uncertainty has normalisation effect of more than 10.0%'
    For uncertainty lumi there were  1  such warnings
>>>There were no warnings of type  'Uncertainty probably has no genuine shape effect'
>>>There were no warnings of type  'Empty process'
>>>There were no warnings of type  'Bins of the template empty in background'
>>>There were  1 warnings of type  'Histogram bin errors are not sqrt(sumw2), needed for accurate bin-by-bin uncertainties'
    For bin bin1 there were  1  such warnings. The affected processes are:  {"exp_nSw2_nPsn": "BinErrorIsSqrtN"}
>>>There were no warnings of type  'Bins of the background template have a relative bin error larger than 300.0%'
>>>There were no alerts of type  'Small signal process'
>>>There were no alerts of type  'Shape uncertainties with 1 bin only. You can consider replacing them with lnN'

_nSw2_wPsn
[SetFlag] Changing value of flag "check-negative-bins-on-import" from 1 to 0
[SetFlag] Changing value of flag "workspaces-use-clone" from 0 to 1
================================
=======Validation results=======
================================
>>>There were no warnings of type  'up/down templates vary the yield in the same direction'
>>>There were no warnings of type  'up/down templates are identical'
>>>There were no warnings of type  'At least one of the up/down systematic uncertainty templates is empty'
>>>There were  1 warnings of type  'Uncertainty has normalisation effect of more than 10.0%'
    For uncertainty lumi there were  1  such warnings
>>>There were no warnings of type  'Uncertainty probably has no genuine shape effect'
>>>There were no warnings of type  'Empty process'
>>>There were no warnings of type  'Bins of the template empty in background'
>>>There were  1 warnings of type  'Histogram bin errors are not sqrt(sumw2), needed for accurate bin-by-bin uncertainties'
    For bin bin1 there were  1  such warnings. The affected processes are:  {"exp_nSw2_wPsn": "BinErrorOption=TH1::kPoisson"}
>>>There were no warnings of type  'Bins of the background template have a relative bin error larger than 300.0%'
>>>There were no alerts of type  'Small signal process'
>>>There were no alerts of type  'Shape uncertainties with 1 bin only. You can consider replacing them with lnN'

_wSw2_nPsn
[SetFlag] Changing value of flag "check-negative-bins-on-import" from 1 to 0
[SetFlag] Changing value of flag "workspaces-use-clone" from 0 to 1
================================
=======Validation results=======
================================
>>>There were no warnings of type  'up/down templates vary the yield in the same direction'
>>>There were no warnings of type  'up/down templates are identical'
>>>There were no warnings of type  'At least one of the up/down systematic uncertainty templates is empty'
>>>There were  1 warnings of type  'Uncertainty has normalisation effect of more than 10.0%'
    For uncertainty lumi there were  1  such warnings
>>>There were no warnings of type  'Uncertainty probably has no genuine shape effect'
>>>There were no warnings of type  'Empty process'
>>>There were no warnings of type  'Bins of the template empty in background'
>>>There were no warnings of type  'Histogram bin errors are not sqrt(sumw2), needed for accurate bin-by-bin uncertainties'
>>>There were no warnings of type  'Bins of the background template have a relative bin error larger than 300.0%'
>>>There were no alerts of type  'Small signal process'
>>>There were no alerts of type  'Shape uncertainties with 1 bin only. You can consider replacing them with lnN'

_wSw2_wPsn
[SetFlag] Changing value of flag "check-negative-bins-on-import" from 1 to 0
[SetFlag] Changing value of flag "workspaces-use-clone" from 0 to 1
================================
=======Validation results=======
================================
>>>There were no warnings of type  'up/down templates vary the yield in the same direction'
>>>There were no warnings of type  'up/down templates are identical'
>>>There were no warnings of type  'At least one of the up/down systematic uncertainty templates is empty'
>>>There were  1 warnings of type  'Uncertainty has normalisation effect of more than 10.0%'
    For uncertainty lumi there were  1  such warnings
>>>There were no warnings of type  'Uncertainty probably has no genuine shape effect'
>>>There were no warnings of type  'Empty process'
>>>There were no warnings of type  'Bins of the template empty in background'
>>>There were  1 warnings of type  'Histogram bin errors are not sqrt(sumw2), needed for accurate bin-by-bin uncertainties'
    For bin bin1 there were  1  such warnings. The affected processes are:  {"exp_wSw2_wPsn": "BinErrorOption=TH1::kPoisson"}
>>>There were no warnings of type  'Bins of the background template have a relative bin error larger than 300.0%'
>>>There were no alerts of type  'Small signal process'
>>>There were no alerts of type  'Shape uncertainties with 1 bin only. You can consider replacing them with lnN'

_largeBinErr
[SetFlag] Changing value of flag "check-negative-bins-on-import" from 1 to 0
[SetFlag] Changing value of flag "workspaces-use-clone" from 0 to 1
================================
=======Validation results=======
================================
>>>There were no warnings of type  'up/down templates vary the yield in the same direction'
>>>There were no warnings of type  'up/down templates are identical'
>>>There were no warnings of type  'At least one of the up/down systematic uncertainty templates is empty'
>>>There were  1 warnings of type  'Uncertainty has normalisation effect of more than 10.0%'
    For uncertainty lumi there were  1  such warnings
>>>There were no warnings of type  'Uncertainty probably has no genuine shape effect'
>>>There were no warnings of type  'Empty process'
>>>There were no warnings of type  'Bins of the template empty in background'
>>>There were no warnings of type  'Histogram bin errors are not sqrt(sumw2), needed for accurate bin-by-bin uncertainties'
>>>There were  2 warnings of type  'Bins of the background template have a relative bin error larger than 300.0%'
    For bin bin1 there were  2  such warnings. The affected bins of the template are:  [1, 3]
>>>There were no alerts of type  'Small signal process'
>>>There were no alerts of type  'Shape uncertainties with 1 bin only. You can consider replacing them with lnN'

_sqrtNBinErr
[SetFlag] Changing value of flag "check-negative-bins-on-import" from 1 to 0
[SetFlag] Changing value of flag "workspaces-use-clone" from 0 to 1
================================
=======Validation results=======
================================
>>>There were no warnings of type  'up/down templates vary the yield in the same direction'
>>>There were no warnings of type  'up/down templates are identical'
>>>There were no warnings of type  'At least one of the up/down systematic uncertainty templates is empty'
>>>There were  1 warnings of type  'Uncertainty has normalisation effect of more than 10.0%'
    For uncertainty lumi there were  1  such warnings
>>>There were no warnings of type  'Uncertainty probably has no genuine shape effect'
>>>There were no warnings of type  'Empty process'
>>>There were no warnings of type  'Bins of the template empty in background'
>>>There were  1 warnings of type  'Histogram bin errors are not sqrt(sumw2), needed for accurate bin-by-bin uncertainties'
    For bin bin1 there were  1  such warnings. The affected processes are:  {"exp_sqrtNBinErr": "BinErrorIsSqrtN"}
>>>There were no warnings of type  'Bins of the background template have a relative bin error larger than 300.0%'
>>>There were no alerts of type  'Small signal process'
>>>There were no alerts of type  'Shape uncertainties with 1 bin only. You can consider replacing them with lnN'
```

Tagging @anigamova