### PR TITLE
adding shapeN to the datacard parser

### DIFF
--- a/CombineTools/src/CombineHarvester_Datacards.cc
+++ b/CombineTools/src/CombineHarvester_Datacards.cc
@@ -508,7 +508,7 @@ int CombineHarvester::ParseDatacard(std::string const& filename,
         }
         sys->set_name(words[i][0]);
         std::string type = words[i][1];
-        if (!contains(std::vector<std::string>{"shape", "shape?", "shapeN2", "shapeU", "lnN", "lnU"},
+        if (!contains(std::vector<std::string>{"shape", "shape?", "shapeN", "shapeN2", "shapeU", "lnN", "lnU"},
                       type)) {
           throw std::runtime_error(
               FNERROR("Systematic type " + type + " not supported"));
@@ -532,7 +532,7 @@ int CombineHarvester::ParseDatacard(std::string const& filename,
           sys->set_value_u(boost::lexical_cast<double>(words[i][p]));
           sys->set_asymm(false);
         }
-        if (sys->type() == "shape" || sys->type() == "shapeN2" ||
+        if (sys->type() == "shape" || sys->type() == "shapeN" || sys->type() == "shapeN2" ||
             sys->type() == "shapeU") {
           sys->set_scale(boost::lexical_cast<double>(words[i][p]));
           LoadShapes(sys.get(), hist_mapping);
@@ -553,7 +553,7 @@ int CombineHarvester::ParseDatacard(std::string const& filename,
             sys->set_scale(boost::lexical_cast<double>(words[i][p]));
           }
         }
-        if (sys->type() == "shape" || sys->type() == "shapeN2" ||
+        if (sys->type() == "shape" || sys->type() == "shapeN" || sys->type() == "shapeN2" ||
             sys->type() == "shapeU")
           sys->set_asymm(true);
 
@@ -1104,6 +1104,7 @@ void CombineHarvester::WriteDatacard(std::string const& name,
     bool seen_lnN = false;
     bool seen_lnU = false;
     bool seen_shape = false;
+    bool seen_shapeN = false;
     bool seen_shapeN2 = false;
     bool seen_shapeU = false;
     if (param_set.count(sys)) continue;
@@ -1123,8 +1124,9 @@ void CombineHarvester::WriteDatacard(std::string const& name,
                   : (format("%g") % ptr->value_u()).str();
           break;
         }
-        if (tp == "shape" || tp == "shapeN2" || tp == "shapeU") {
+        if (tp == "shape" || tp == "shapeN" || tp == "shapeN2" || tp == "shapeU") {
           if (tp == "shape") seen_shape = true;
+          if (tp == "shapeN") seen_shapeN = true;
           if (tp == "shapeN2") seen_shapeN2 = true;
           if (tp == "shapeU") seen_shapeU = true;
           line[p + 2] = (format("%g") % ptr->scale()).str();
@@ -1156,6 +1158,8 @@ void CombineHarvester::WriteDatacard(std::string const& name,
     }
     if (seen_shapeN2) {
       line[1] = "shapeN2";
+    } else if (seen_shapeN) {
+      line[1] = "shapeN";
     } else if (seen_shapeU) {
       line[1] = "shapeU";
     } else if (seen_lnU) {

--- a/CombineTools/src/CombineHarvester_Evaluate.cc
+++ b/CombineTools/src/CombineHarvester_Evaluate.cc
@@ -440,7 +440,7 @@ TH1F CombineHarvester::GetShapeInternal(ProcSystMap const& lookup,
         if (sys_it->asymm()) {
           p_rate *= logKappaForX(x * sys_it->scale(), sys_it->value_d(),
                                  sys_it->value_u());
-          if (sys_it->type() == "shape" || sys_it->type() == "shapeN2" ||
+          if (sys_it->type() == "shape" || sys_it->type() == "shapeN" || sys_it->type() == "shapeN2" ||
               sys_it->type() == "shapeU") {
             bool linear = true;
             if (sys_it->type() == "shapeN2") linear = false;
@@ -554,7 +554,7 @@ TH2F CombineHarvester::Get2DShapeInternal(ProcSystMap const& lookup,
         if (sys_it->asymm()) {
           p_rate *= logKappaForX(x * sys_it->scale(), sys_it->value_d(),
                                  sys_it->value_u());
-          if (sys_it->type() == "shape" || sys_it->type() == "shapeN2" ||
+          if (sys_it->type() == "shape" || sys_it->type() == "shapeN" || sys_it->type() == "shapeN2" ||
               sys_it->type() == "shapeU") {
             bool linear = true;
             if (sys_it->type() == "shapeN2") linear = false;


### PR DESCRIPTION
shapeN was missing from combineTools datacards parser and evaluate. this PR simply add it on top of the other systematics types.